### PR TITLE
merge branch "Feature/web tests improvements" into main

### DIFF
--- a/Examples/ExampleBase/Constants.cs
+++ b/Examples/ExampleBase/Constants.cs
@@ -21,5 +21,10 @@
 
         public const string LICENSE_KEY_ENV_VAR = "DEVICEDETECTIONLICENSEKEY_DOTNET";
 
+        /// <summary>
+        /// Ports used for running web examples and their tests.
+        /// </summary>
+        public static readonly int[] LOCALHOST_HTTP_PORTS = new int[] { 5000 };
+        public static readonly int[] LOCALHOST_HTTPS_PORTS = new int[] { 5001, 5002 };
     }
 }

--- a/Examples/ExampleBase/Constants.cs
+++ b/Examples/ExampleBase/Constants.cs
@@ -24,7 +24,7 @@
         /// <summary>
         /// Ports used for running web examples and their tests.
         /// </summary>
-        public static readonly int[] LOCALHOST_HTTP_PORTS = new int[] { 5000 };
+        public static readonly int[] LOCALHOST_HTTP_PORTS = new int[] { 5101 };
         public static readonly int[] LOCALHOST_HTTPS_PORTS = new int[] { 5001, 5002 };
     }
 }

--- a/Examples/OnPremise/GettingStarted-Web/GettingStarted-Web.csproj
+++ b/Examples/OnPremise/GettingStarted-Web/GettingStarted-Web.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.19" />
+    <PackageReference Include="WebDriverManager" Version="2.16.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/OnPremise/GettingStarted-Web/Program.cs
+++ b/Examples/OnPremise/GettingStarted-Web/Program.cs
@@ -61,7 +61,8 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb
                         Constants.LOCALHOST_HTTP_PORTS.ForEach(port => options.ListenAnyIP(port));
                         Constants.LOCALHOST_HTTPS_PORTS.ForEach(port => options.ListenAnyIP(port, config => config.UseHttps()));
                     })
-                    .UseStartup<Startup>();
+                    .UseStartup<Startup>()
+                    .UseStaticWebAssets();
                 });
 
         /// <summary>

--- a/Examples/OnPremise/GettingStarted-Web/Program.cs
+++ b/Examples/OnPremise/GettingStarted-Web/Program.cs
@@ -20,17 +20,17 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
-using FiftyOne.DeviceDetection.Examples;
 using FiftyOne.DeviceDetection.Hash.Engine.OnPremise.FlowElements;
 using FiftyOne.Pipeline.Core.Configuration;
+using FiftyOne.Pipeline.Web.Shared;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using NUglify.Helpers;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb
 {
@@ -55,6 +55,11 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb
                     {
                         c.AddJsonFile("appsettings.json")
                             .AddInMemoryCollection(overrides);
+                    })
+                    .UseKestrel(options =>
+                    {
+                        Constants.LOCALHOST_HTTP_PORTS.ForEach(port => options.ListenAnyIP(port));
+                        Constants.LOCALHOST_HTTPS_PORTS.ForEach(port => options.ListenAnyIP(port, config => config.UseHttps()));
                     })
                     .UseStartup<Startup>();
                 });
@@ -81,7 +86,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb
                 .AddJsonFile("appsettings.json")
                 .Build();
             // Bind the configuration to a pipeline options instance
-            PipelineOptions options = new PipelineOptions();
+            PipelineOptions options = new PipelineWebIntegrationOptions();
             var section = config.GetRequiredSection("PipelineOptions");
             // Use the 'ErrorOnUnknownConfiguration' option to warn us if we've got any
             // misnamed configuration keys.

--- a/Examples/OnPremise/GettingStarted-Web/Startup.cs
+++ b/Examples/OnPremise/GettingStarted-Web/Startup.cs
@@ -21,6 +21,7 @@
  * ********************************************************************* */
 
 using FiftyOne.DeviceDetection.Hash.Engine.OnPremise.FlowElements;
+using FiftyOne.DeviceDetection.Uach;
 using FiftyOne.Pipeline.Engines.FiftyOne.FlowElements;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -117,6 +118,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb
             // Add the hash engine builder to services so that the system can find the builder
             // when it needs to.
             services.AddSingleton<DeviceDetectionHashEngineBuilder>();
+            services.AddSingleton<UachJsConversionElementBuilder>();
             // Configure the services needed by device detection and create the 51Degrees Pipeline
             // instance that will be used to process requests.
             services.AddFiftyOne(Configuration);

--- a/Examples/OnPremise/GettingStarted-Web/appsettings.json
+++ b/Examples/OnPremise/GettingStarted-Web/appsettings.json
@@ -12,6 +12,10 @@
   "PipelineOptions": {
     "Elements": [
       {
+        // Required to unpack the GetHighEntropyValues base 64 encoded string into UACH HTTP headers.
+        "BuilderName": "UachJsConversionElement"
+      },
+      {
         "BuilderName": "DeviceDetectionHashEngineBuilder",
         "BuildParameters": {
           "DataFile": "51Degrees-LiteV4.1.hash",
@@ -19,10 +23,13 @@
           "AutoUpdate": false,
           "PerformanceProfile": "LowMemory",
           "DataFileSystemWatcher": false,
-          "DataUpdateOnStartUp": false
+          "DataUpdateOnStartUp": false,
+          // Explicitly include just the properties used by the example.
+          "Properties": "HardwareVendor,HardwareModel,HardwareName,IsMobile,JavascriptGetHighEntropyValues,Promise,Fetch,DeviceType,PlatformVendor,PlatformName,PlatformVersion,BrowserVendor,BrowserName,BrowserVersion,ScreenPixelsWidth,ScreenPixelsHeight,JavascriptScreenPixelsWidth,JavascriptScreenPixelsHeight"
         }
       },
       {
+        // Required to add Javascript and JSON end points for 51Degrees.core.js and 
         "BuilderName": "JavaScriptBuilderElement",
         "BuildParameters": {
           "Minify": true

--- a/Examples/OnPremise/GettingStarted-Web/wwwroot/static.html
+++ b/Examples/OnPremise/GettingStarted-Web/wwwroot/static.html
@@ -1,0 +1,67 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width">
+    <link rel="stylesheet" href="/css/site.css">
+    <title>Example GetHighEntropyValues HTML</title>
+</head>
+<body>
+    <div id="content"></div>
+    <script async src="https://localhost:5002/51Degrees.core.js" type="text/javascript"></script>
+    <script>
+        window.onload = function () {
+            // Subscribe to the 'complete' event.
+            fod.complete(function (data) {
+
+                // When the event fires, use the supplied data to populate a new table.
+                let fieldValues = [];
+
+                var hardwareName = typeof data.device.hardwarename == "undefined" ?
+                    "Unknown" : data.device.hardwarename.join(", ")
+                fieldValues.push(["Hardware Name: ", hardwareName]);
+                fieldValues.push(["Platform: ",
+                    data.device.platformname + " " + data.device.platformversion]);
+                fieldValues.push(["Browser: ",
+                    data.device.browsername + " " + data.device.browserversion]);
+                fieldValues.push(["Screen width (pixels): ", data.device.screenpixelswidth]);
+                fieldValues.push(["Screen height (pixels): ", data.device.screenpixelsheight]);
+                displayValues(fieldValues);
+            });
+        }
+
+        // Helper function to add a table that displays the supplied values.
+        function displayValues(fieldValues) {
+            var table = document.createElement("table");
+            var tr = document.createElement("tr");
+            addToRow(tr, "th", "Key", false);
+            addToRow(tr, "th", "Value", false);
+            table.appendChild(tr);
+
+            fieldValues.forEach(function (entry) {
+                var tr = document.createElement("tr");
+                tr.classList.add("lightyellow");
+                addToRow(tr, "td", entry[0], true);
+                addToRow(tr, "td", entry[1], false);
+                table.appendChild(tr);
+            });
+
+            var element = document.getElementById("content");
+            element.appendChild(table);
+        }
+
+        // Helper function to add an entry to a table row.
+        function addToRow(row, elementName, text, strong) {
+            var entry = document.createElement(elementName);
+            var textNode = document.createTextNode(text);
+            if (strong === true) {
+                var strongNode = document.createElement("strong");
+                strongNode.appendChild(textNode);
+                textNode = strongNode;
+            }
+            entry.appendChild(textNode);
+            row.appendChild(entry);
+        }
+    </script>
+</body>
+</html>

--- a/Examples/OnPremise/GettingStarted-Web/wwwroot/static.html
+++ b/Examples/OnPremise/GettingStarted-Web/wwwroot/static.html
@@ -4,10 +4,15 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="/css/site.css">
-    <title>Example GetHighEntropyValues HTML</title>
+    <title>Example GetHighEntropyValues Static HTML</title>
 </head>
 <body>
     <div id="content"></div>
+    <!--
+        The JavascriptGetHighEntropyValues javascript will be used to determine the UACH values. When port 5002 
+        resource is accessed from port 5001 this will be a cross origin script include. This static page can therefore
+        be used to verify that the CORS configuration is valid.
+    -->
     <script async src="https://localhost:5002/51Degrees.core.js" type="text/javascript"></script>
     <script>
         window.onload = function () {

--- a/Examples/OnPremise/GettingStarted-Web/wwwroot/static.html
+++ b/Examples/OnPremise/GettingStarted-Web/wwwroot/static.html
@@ -13,7 +13,7 @@
         resource is accessed from port 5001 this will be a cross origin script include. This static page can therefore
         be used to verify that the CORS configuration is valid.
     -->
-    <script async src="https://localhost:5002/51Degrees.core.js" type="text/javascript"></script>
+    <script async src="https://localhost:5001/51Degrees.core.js" type="text/javascript"></script>
     <script>
         window.onload = function () {
             // Subscribe to the 'complete' event.

--- a/Examples/OnPremise/GettingStarted-Web/wwwroot/testpage.html
+++ b/Examples/OnPremise/GettingStarted-Web/wwwroot/testpage.html
@@ -1,0 +1,24 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <title>Test Page</title>
+    <script async src="https://localhost:5001/51Degrees.core.js"></script>
+</head>
+<body>
+    <script>
+            var test = 'loading';
+            var spw = 0;
+            var sph = 0;
+            var deviceid = 'loading';
+
+            window.onload = function() {
+                fod.complete(function(data) {
+                    spw = data.device['screenpixelswidth'];
+                    sph = data.device['screenpixelsheight'];
+                    deviceid = data.device['deviceid'];
+                    test = 'complete';
+                });
+            }
+    </script>
+</body>
+</html>

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/FiftyOne.DeviceDetection.Example.Tests.Web.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/FiftyOne.DeviceDetection.Example.Tests.Web.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -91,6 +91,9 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 Examples.OnPremise.GettingStartedWeb.Program.Main(
                     new string[] { }), 
                     stopToken.Token);
+            
+            Thread.Sleep(TimeSpan.FromSeconds(10));
+            
             using (var http = new HttpClient())
             {
                 var request = new HttpRequestMessage
@@ -144,6 +147,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 Examples.OnPremise.GettingStartedWeb.Program.Main(
                     new string[] { }),
                     stopToken.Token);
+            Thread.Sleep(TimeSpan.FromSeconds(10));
 
             using (_driver)
             {
@@ -184,7 +188,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 Examples.OnPremise.GettingStartedWeb.Program.Main(
                     new string[] { }),
                     stopToken.Token);
-
+            Thread.Sleep(TimeSpan.FromSeconds(10));
             using (_driver)
             {
                 // Enable DevTools
@@ -237,7 +241,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 Examples.OnPremise.GettingStartedWeb.Program.Main(
                     new string[] { }),
                     stopToken.Token);
-
+            Thread.Sleep(TimeSpan.FromSeconds(10));
             using (_driver)
             {
                 // Enable DevTools

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -76,7 +76,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Get,
-                    RequestUri = new Uri(String.Format("http://localhost:{0}",port))
+                    RequestUri = new Uri(String.Format("http://127.0.01:{0}",port))
                 };
                 request.Headers.Add("User-Agent", "abc");
 
@@ -103,8 +103,8 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
             {
                 return new[]
                 {
-                    new object[] { $"https://localhost:{Constants.LOCALHOST_HTTPS_PORTS[0]}" },
-                    new object[] { $"https://localhost:{Constants.LOCALHOST_HTTPS_PORTS[1]}" }
+                    new object[] { $"https://127.0.01:{Constants.LOCALHOST_HTTPS_PORTS[0]}" },
+                    new object[] { $"https://127.0.01:{Constants.LOCALHOST_HTTPS_PORTS[1]}" }
                 };
 
             }

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -123,7 +123,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 if (response != null) { response.Dispose(); }
             }
             stopToken.Cancel(false);
-            await serverTask;
+            serverTask.Wait();
 
         }
 
@@ -192,7 +192,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 _driver.Quit();
             }
             stopToken.Cancel(false);
-            await serverTask;
+            serverTask.Wait();
 
         }
 
@@ -251,7 +251,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 _driver.Quit();
             }
             stopToken.Cancel(false);
-            await serverTask;
+            serverTask.Wait();
         }
         [DataTestMethod]
         [DynamicData(nameof(UrlsData))]
@@ -292,7 +292,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 _driver.Quit();
             }
             stopToken.Cancel(false);
-            await serverTask;
+            serverTask.Wait();
 
         }
        

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -97,7 +97,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                     new string[] { }), 
                     stopToken.Token);
                     
-            Thread.Sleep(TimeSpan.FromSeconds(5));
+            Thread.Sleep(TimeSpan.FromSeconds(10));
 
             using (var http = new HttpClient())
             {
@@ -151,6 +151,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 Examples.OnPremise.GettingStartedWeb.Program.Main(
                     new string[] { }),
                     stopToken.Token);
+            Thread.Sleep(TimeSpan.FromSeconds(10));
 
             using (_driver)
             {
@@ -192,7 +193,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 Examples.OnPremise.GettingStartedWeb.Program.Main(
                     new string[] { }),
                     stopToken.Token);
-
+            Thread.Sleep(TimeSpan.FromSeconds(10));
             using (_driver)
             {
                 // Enable DevTools
@@ -245,6 +246,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 Examples.OnPremise.GettingStartedWeb.Program.Main(
                     new string[] { }),
                     stopToken.Token);
+            Thread.Sleep(TimeSpan.FromSeconds(10));
             using (_driver)
             {
                 // Enable DevTools

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -21,12 +21,22 @@
  * ********************************************************************* */
 
 using FiftyOne.DeviceDetection.Examples;
+using Microsoft.AspNetCore.HttpLogging;
+using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+using OpenQA.Selenium.DevTools;
+using OpenQA.Selenium.DevTools.V113;
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using static System.Net.WebRequestMethods;
 
 namespace FiftyOne.DeviceDetection.Example.Tests.Web
 {
@@ -72,6 +82,130 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 if (response != null) { response.Dispose(); }
             }
             stopToken.Cancel(false);
+
+
         }
+
+        /// <summary>
+        /// Ports on which the example is listening are defined in <see cref="Constants"/>
+        /// </summary>
+        public static IEnumerable<object[]> UrlsData
+        {
+            get
+            {
+                return new[]
+                {
+                    new object[] { $"https://localhost:{Constants.LOCALHOST_HTTPS_PORTS[0]}/static.html" },
+                    new object[] { $"https://localhost:{Constants.LOCALHOST_HTTPS_PORTS[1]}/static.html" }
+                };
+
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the 51d cookie is populated.
+        /// </summary>
+        /// <param name="url"></param>
+        [DataTestMethod]
+        [DynamicData(nameof(UrlsData))]
+        public void VerifyExample_GetHighEntropyValues_Populates_51D_Cookie(string url)
+        {
+            // Arrange
+            var stopToken = new CancellationTokenSource();
+            var serverTask = Task.Run(() =>
+                Examples.OnPremise.GettingStartedWeb.Program.Main(
+                    new string[] { }),
+                    stopToken.Token);
+
+            // Set up Selenium WebDriver
+            ChromeOptions options = new ChromeOptions();
+            options.AddArgument("--headless=new");
+            using (var driver = new ChromeDriver(options))
+            {
+                // Enable DevTools
+                var devTools = driver as IDevTools;
+                var session = devTools.GetDevToolsSession();
+
+                var domains = session.GetVersionSpecificDomains<OpenQA.Selenium.DevTools.V113.DevToolsSessionDomains>();
+                domains.Network.Enable(new OpenQA.Selenium.DevTools.V113.Network.EnableCommandSettings());
+
+
+                // Act
+                driver.Navigate().GoToUrl(url);
+
+                // Wait for the page to load
+                Thread.Sleep(TimeSpan.FromSeconds(3));
+
+                var cookies = domains.Network.GetAllCookies().Result;
+                var fod_cookie = cookies.Cookies.Where(c => c.Name == "51D_GetHighEntropyValues").Single();
+                var bytes = new Span<byte>(new byte[1024]);
+
+                // Assert
+                Assert.IsNotNull(fod_cookie);
+                Assert.IsTrue(Convert.TryFromBase64String(fod_cookie.Value, bytes, out int _));
+
+                // Quit the driver
+                driver.Quit();
+            }
+            stopToken.Cancel(false);
+
+        }
+        [TestMethod]
+        public void VerifyExample_GetHighEntropyValues_Contains_CORS_Response_Header()
+        {
+            // Arrange
+            var stopToken = new CancellationTokenSource();
+            var serverTask = Task.Run(() =>
+                Examples.OnPremise.GettingStartedWeb.Program.Main(
+                    new string[] { }),
+                    stopToken.Token);
+
+            // Set up Selenium WebDriver
+            ChromeOptions options = new ChromeOptions();
+            options.AddArgument("--headless=new");
+            using (var driver = new ChromeDriver(options))
+            {
+                // Enable DevTools
+                var devTools = driver as IDevTools;
+                var session = devTools.GetDevToolsSession();
+
+                var domains = session.GetVersionSpecificDomains<OpenQA.Selenium.DevTools.V113.DevToolsSessionDomains>();
+                domains.Network.Enable(new OpenQA.Selenium.DevTools.V113.Network.EnableCommandSettings());
+
+                Dictionary<string, string> headerValuePairs = new();
+
+                // Get Response Headers
+                domains.Network.ResponseReceived += (sender, e) =>
+                {
+                    var headers = e.Response.Headers;
+                    var responseUrl = e.Response.Url;
+                    if (responseUrl.Equals($"https://localhost:{Constants.LOCALHOST_HTTPS_PORTS[0]}/51dpipeline/json"))
+                    {
+                        foreach (var header in headers)
+                        {
+                            headerValuePairs.Add(header.Key.ToLower(), header.Value);
+                        }
+                    }
+                };
+
+                // Act
+                // Do a cross origin request
+                var url = UrlsData.ElementAt(1).Single().ToString();
+                driver.Navigate().GoToUrl(url);
+
+                // Wait for the page to load
+                Thread.Sleep(TimeSpan.FromSeconds(3));
+
+                // Assert
+                // Verify that the response contains the header
+                Assert.IsTrue(headerValuePairs.ContainsKey("access-control-allow-origin"));
+
+                // Quit the driver
+                driver.Quit();
+            }
+            stopToken.Cancel(false);
+        }
+
     }
+
 }

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -23,9 +23,6 @@
 using FiftyOne.DeviceDetection.Examples;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -33,70 +30,48 @@ using System.Threading.Tasks;
 
 namespace FiftyOne.DeviceDetection.Example.Tests.Web
 {
-    /// <summary>
-    /// </summary>
     [TestClass]
     public class GettingStartedOnPremiseTest : WebExampleTestBase
     {
-        private string DATA_FILE_PATH { get; set; }
-
         /// <summary>
-        /// Test that the 'GettingStartedWeb' example is able to run without crashing
+        /// Test that the 'GettingStarted-Web' example is able to run and 
+        /// returns code 200 upon https request.
         /// </summary>
         /// <returns></returns>
         [TestMethod]
-        public async Task VerifyExample_OnPremise()
+        public async Task VerifyExample_OnPremise_Returns_Status_Code_200()
         {
-            GetKeyFromEnv("DEVICEDETECTIONDATAFILE", v => DATA_FILE_PATH = v);
-            await VerifyExample<Examples.OnPremise.GettingStartedWeb.Startup>(DATA_FILE_PATH);
-        }
+            //Arrange 
 
-        private async Task VerifyExample<T>(
-            string dataFilePath) where T : class
-        {
-            if(string.IsNullOrWhiteSpace(dataFilePath))
-            {
-                dataFilePath = ExampleUtils.FindFile("51Degrees-LiteV4.1.hash");
-            }
-
-            if (string.IsNullOrWhiteSpace(dataFilePath))
-            {
-                Assert.Inconclusive("Unable to run this test as no data file path was passed " +
-                    "from the relevant environment variables. " +
-                    "(See ClientHintsExampleTestBase.GetEnvVars)");
-            }
-
-            // Determine the path to the app settings file we need to use
-            string appSettingsPath = Environment.CurrentDirectory;
-            int pos = appSettingsPath.IndexOf("Tests");
-            appSettingsPath = appSettingsPath.Remove(pos);
-            appSettingsPath = Path.Combine(
-                appSettingsPath,
-                "Examples",
-                "OnPremise",
-                "GettingStarted-Web",
-                "appsettings.json");
-
-            // Create the web server to handle the requests
-            using (var server = InitializeOnPremTestServer<T>(
-                appSettingsPath, null, dataFilePath))
-            using (var http = server.CreateClient())
+            // We are using the same port that the example is listening on.
+            int port = Constants.LOCALHOST_HTTP_PORTS[0];
+            var stopToken = new CancellationTokenSource();
+            
+            // Running the main method of the example to ensure we are testing
+            // the same code and that the same configuraton is used by both tests and examples
+            var serverTask = Task.Run(() => 
+                Examples.OnPremise.GettingStartedWeb.Program.Main(
+                    new string[] { }), 
+                    stopToken.Token);
+            using (var http = new HttpClient())
             {
                 var request = new HttpRequestMessage
                 {
-                    Method = HttpMethod.Get
+                    Method = HttpMethod.Get,
+                    RequestUri = new Uri(String.Format("http://localhost:{0}",port))
                 };
                 request.Headers.Add("User-Agent", "abc");
+
+                // Act
                 var response = await http.SendAsync(request);
 
-                // Verify the request was successful.
+                // Assert
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
                 if (request != null) { request.Dispose(); }
                 if (response != null) { response.Dispose(); }
             }
+            stopToken.Cancel(false);
         }
-
     }
-
 }

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -41,6 +41,9 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using static System.Net.WebRequestMethods;
+using WebDriverManager;
+using WebDriverManager.DriverConfigs.Impl;
+using WebDriverManager.Helpers;
 
 
 namespace FiftyOne.DeviceDetection.Example.Tests.Web
@@ -55,12 +58,14 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
         [TestInitialize]
         public void Init()
         {
+            new DriverManager().SetUpDriver(new ChromeConfig(), VersionResolveStrategy.MatchingBrowser);
             var chromeOptions = new ChromeOptions();
             chromeOptions.AcceptInsecureCertificates = true;
             // run in headless mode.
             chromeOptions.AddArgument("--headless=new");
             try
             {
+            
                 _driver = new ChromeDriver(chromeOptions);
             }
             catch (WebDriverException)
@@ -91,6 +96,8 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 Examples.OnPremise.GettingStartedWeb.Program.Main(
                     new string[] { }), 
                     stopToken.Token);
+                    
+            Thread.Sleep(TimeSpan.FromSeconds(5));
 
             using (var http = new HttpClient())
             {

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -76,7 +76,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Get,
-                    RequestUri = new Uri(String.Format("http://127.0.01:{0}",port))
+                    RequestUri = new Uri(String.Format("http://127.0.0.1:{0}",port))
                 };
                 request.Headers.Add("User-Agent", "abc");
 
@@ -103,8 +103,8 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
             {
                 return new[]
                 {
-                    new object[] { $"https://127.0.01:{Constants.LOCALHOST_HTTPS_PORTS[0]}" },
-                    new object[] { $"https://127.0.01:{Constants.LOCALHOST_HTTPS_PORTS[1]}" }
+                    new object[] { $"https://127.0.0.1:{Constants.LOCALHOST_HTTPS_PORTS[0]}" },
+                    new object[] { $"https://127.0.0.1:{Constants.LOCALHOST_HTTPS_PORTS[1]}" }
                 };
 
             }

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -98,6 +98,11 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                     stopToken.Token);
                     
             Thread.Sleep(TimeSpan.FromSeconds(10));
+            
+            if (serverTask.IsFaulted)
+            {
+                throw serverTask.Exception;
+            }
 
             using (var http = new HttpClient())
             {
@@ -152,6 +157,11 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                     new string[] { }),
                     stopToken.Token);
             Thread.Sleep(TimeSpan.FromSeconds(10));
+            
+            if (serverTask.IsFaulted)
+            {
+                throw serverTask.Exception;
+            }
 
             using (_driver)
             {
@@ -194,6 +204,10 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                     new string[] { }),
                     stopToken.Token);
             Thread.Sleep(TimeSpan.FromSeconds(10));
+            if (serverTask.IsFaulted)
+            {
+                throw serverTask.Exception;
+            }
             using (_driver)
             {
                 // Enable DevTools
@@ -247,6 +261,10 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                     new string[] { }),
                     stopToken.Token);
             Thread.Sleep(TimeSpan.FromSeconds(10));
+            if (serverTask.IsFaulted)
+            {
+                throw serverTask.Exception;
+            }
             using (_driver)
             {
                 // Enable DevTools

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -40,6 +40,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using static System.Net.WebRequestMethods;
 
+
+/// TODO: Verify that selenium is setup and produces a warning instead of failing when it isnt installed 
+/// inconclusive.
 namespace FiftyOne.DeviceDetection.Example.Tests.Web
 {
     [TestClass]
@@ -124,8 +127,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
 
             // Set up Selenium WebDriver
             ChromeOptions options = SetupChromeOptions();
-            ChromeDriverService service = SetupChromeService();
-            using (var driver = new ChromeDriver(service, options))
+            using (var driver = new ChromeDriver(options))
             {
                 // Enable DevTools
                 var devTools = driver as IDevTools;
@@ -167,9 +169,8 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
 
             // Set up Selenium WebDriver
             ChromeOptions options = SetupChromeOptions();
-            ChromeDriverService service = SetupChromeService();
 
-            using (var driver = new ChromeDriver(service, options))
+            using (var driver = new ChromeDriver(options))
             {
                 // Enable DevTools
                 var devTools = driver as IDevTools;
@@ -224,9 +225,8 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
 
             // Set up Selenium WebDriver
             ChromeOptions options = SetupChromeOptions();
-            ChromeDriverService service = SetupChromeService();
 
-            using (var driver = new ChromeDriver(service, options))
+            using (var driver = new ChromeDriver(options))
             {
                 // Enable DevTools
                 var devTools = driver as IDevTools;
@@ -257,15 +257,10 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
         {
             ChromeOptions options = new ChromeOptions();
             options.AddArgument("--headless=new");
-            options.AddArgument("--whitelisted-ips=''");
+            options.AcceptInsecureCertificates = true;
             return options;
         }
-        private static ChromeDriverService SetupChromeService()
-        {
-            ChromeDriverService service = ChromeDriverService.CreateDefaultService();
-            service.WhitelistedIPAddresses = " ";
-            return service;
-        }
+        
     }
 
 }

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -92,8 +92,6 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                     new string[] { }), 
                     stopToken.Token);
 
-            WaitForServer(String.Format("http://localhost:{0}", port));
-
             using (var http = new HttpClient())
             {
                 var request = new HttpRequestMessage
@@ -147,8 +145,6 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                     new string[] { }),
                     stopToken.Token);
 
-            WaitForServer(url);
-
             using (_driver)
             {
                 // Enable DevTools
@@ -180,42 +176,6 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
 
         }
 
-        private static void WaitForServer(string url)
-        {
-            // Wait for the server to start listening on the specified port
-            var timeout = TimeSpan.FromSeconds(10);
-            var stopwatch = Stopwatch.StartNew();
-            while (stopwatch.Elapsed < timeout)
-            {
-                try
-                {
-                    using (var client = new HttpClient())
-                    {
-                        client.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("abc", "1"));
-                        var response = client.GetAsync(url).Result;
-                        if (response.StatusCode.Equals(HttpStatusCode.OK))
-                        {
-                            // Server started successfully
-                            break;
-                        }
-                    }
-                }
-                catch(Exception ex)
-                {
-                    Console.WriteLine(ex.Message);
-                    // Ignore exception and continue looping
-                }
-
-                // Wait for a short interval before the next attempt
-                Task.Delay(500);
-            }
-            if (stopwatch.Elapsed >= timeout)
-            {
-                // Server failed to start within the specified timeout
-                throw new TimeoutException("Failed to start the server within the specified timeout.");
-            }
-        }
-
         [TestMethod]
         public void VerifyExample_GetHighEntropyValues_Contains_CORS_Response_Header()
         {
@@ -225,7 +185,6 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 Examples.OnPremise.GettingStartedWeb.Program.Main(
                     new string[] { }),
                     stopToken.Token);
-            WaitForServer("https://localhost:5001");
 
             using (_driver)
             {

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -123,6 +123,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 if (response != null) { response.Dispose(); }
             }
             stopToken.Cancel(false);
+            await serverTask;
 
         }
 
@@ -191,6 +192,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 _driver.Quit();
             }
             stopToken.Cancel(false);
+            await serverTask;
 
         }
 
@@ -249,6 +251,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 _driver.Quit();
             }
             stopToken.Cancel(false);
+            await serverTask;
         }
         [DataTestMethod]
         [DynamicData(nameof(UrlsData))]
@@ -289,6 +292,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 _driver.Quit();
             }
             stopToken.Cancel(false);
+            await serverTask;
 
         }
        

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -124,7 +124,8 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
 
             // Set up Selenium WebDriver
             ChromeOptions options = SetupChromeOptions();
-            using (var driver = new ChromeDriver(options))
+            ChromeDriverService service = SetupChromeService();
+            using (var driver = new ChromeDriver(service, options))
             {
                 // Enable DevTools
                 var devTools = driver as IDevTools;
@@ -166,7 +167,9 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
 
             // Set up Selenium WebDriver
             ChromeOptions options = SetupChromeOptions();
-            using (var driver = new ChromeDriver(options))
+            ChromeDriverService service = SetupChromeService();
+
+            using (var driver = new ChromeDriver(service, options))
             {
                 // Enable DevTools
                 var devTools = driver as IDevTools;
@@ -221,8 +224,9 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
 
             // Set up Selenium WebDriver
             ChromeOptions options = SetupChromeOptions();
+            ChromeDriverService service = SetupChromeService();
 
-            using (var driver = new ChromeDriver(options))
+            using (var driver = new ChromeDriver(service, options))
             {
                 // Enable DevTools
                 var devTools = driver as IDevTools;
@@ -256,7 +260,12 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
             options.AddArgument("--whitelisted-ips=''");
             return options;
         }
-
+        private static ChromeDriverService SetupChromeService()
+        {
+            ChromeDriverService service = ChromeDriverService.CreateDefaultService();
+            service.WhitelistedIPAddresses = " ";
+            return service;
+        }
     }
 
 }

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedOnPremiseTest.cs
@@ -92,7 +92,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                     new string[] { }), 
                     stopToken.Token);
             
-            Thread.Sleep(TimeSpan.FromSeconds(10));
+            Thread.Sleep(TimeSpan.FromSeconds(20));
             
             using (var http = new HttpClient())
             {
@@ -147,7 +147,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 Examples.OnPremise.GettingStartedWeb.Program.Main(
                     new string[] { }),
                     stopToken.Token);
-            Thread.Sleep(TimeSpan.FromSeconds(10));
+            Thread.Sleep(TimeSpan.FromSeconds(20));
 
             using (_driver)
             {
@@ -163,7 +163,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 _driver.Navigate().GoToUrl(url + STATIC_HTML_ENDPOINT);
                                                 
                 // Wait for the page to load
-                Thread.Sleep(TimeSpan.FromSeconds(3));
+                Thread.Sleep(TimeSpan.FromSeconds(10));
 
                 var cookies = domains.Network.GetAllCookies().Result;
                 var fod_cookie = cookies.Cookies.Where(c => c.Name == "51D_GetHighEntropyValues").Single();
@@ -188,7 +188,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 Examples.OnPremise.GettingStartedWeb.Program.Main(
                     new string[] { }),
                     stopToken.Token);
-            Thread.Sleep(TimeSpan.FromSeconds(10));
+            Thread.Sleep(TimeSpan.FromSeconds(20));
             using (_driver)
             {
                 // Enable DevTools
@@ -220,7 +220,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 _driver.Navigate().GoToUrl(url + STATIC_HTML_ENDPOINT);
 
                 // Wait for the page to load
-                Thread.Sleep(TimeSpan.FromSeconds(3));
+                Thread.Sleep(TimeSpan.FromSeconds(10));
 
                 // Assert
                 // Verify that the response contains the header
@@ -241,7 +241,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
                 Examples.OnPremise.GettingStartedWeb.Program.Main(
                     new string[] { }),
                     stopToken.Token);
-            Thread.Sleep(TimeSpan.FromSeconds(10));
+            Thread.Sleep(TimeSpan.FromSeconds(20));
             using (_driver)
             {
                 // Enable DevTools

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -23,8 +23,6 @@ if ($IsLinux) {
 
 }
 
-dotnet dev-certs https -t 
-
 $env:DEVICEDETECTIONDATAFILE = [IO.Path]::Combine($RepoPath, "device-detection-data", "TAC-HashV41.hash")
 $env:SUPER_RESOURCE_KEY = $Keys.TestResourceKey
 $env:DEVICEDETECTIONLICENSEKEY_DOTNET = $Keys.DeviceDetection

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -23,6 +23,8 @@ if ($IsLinux) {
 
 }
 
+dotnet dev-certs https -t 
+
 $env:DEVICEDETECTIONDATAFILE = [IO.Path]::Combine($RepoPath, "device-detection-data", "TAC-HashV41.hash")
 $env:SUPER_RESOURCE_KEY = $Keys.TestResourceKey
 $env:DEVICEDETECTIONLICENSEKEY_DOTNET = $Keys.DeviceDetection

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -23,6 +23,8 @@ if ($IsLinux) {
 
 }
 
+dotnet dev-certs https
+
 $env:DEVICEDETECTIONDATAFILE = [IO.Path]::Combine($RepoPath, "device-detection-data", "TAC-HashV41.hash")
 $env:SUPER_RESOURCE_KEY = $Keys.TestResourceKey
 $env:DEVICEDETECTIONLICENSEKEY_DOTNET = $Keys.DeviceDetection


### PR DESCRIPTION
TEST: Add tests for GettingStarted onpresmise web example to verify that GetHighEntropyValues populates the cookie with cross origin requests.

FEAT: Add a static html file to the getting started examples.

BUG: Fix the bug that caused the web on premise example to throw ErrorOnUnknownConfiguration. The configuration was using elements from the PipelineWebIntegrationOptions that extends the PipelineOptions.

TEST: Refactor of the on premise web example test to run the main method of the example instead of the startup class which will ensure that any exceptions in the configuration will casue the test to fail
REFACT: Change name of the test to be more descriptive
FEAT: Introduce a constant for http and https ports that are used by both examples and tests
DOC: Add comments to tests