### PR TITLE
Catch `PropertyMissingException` in `Default.aspx`

### DIFF
--- a/Examples/Cloud/Framework-Web/Default.aspx
+++ b/Examples/Cloud/Framework-Web/Default.aspx
@@ -68,12 +68,26 @@
             The following values are determined by sever-side device detection
             on the first request:
         </p>
+        <%
+            string isMobileDeviceString;
+            try
+            {
+                isMobileDeviceString = Request.Browser.IsMobileDevice ? "Yes" : "No";
+            }
+            catch (Exception ex)
+            {
+                isMobileDeviceString = "Unknown";
+        %>
+                <p class="lightred"><%: ex %></p>
+        <%
+            }
+        %>
         <p>
             Note that all values below are retrieved using the strongly typed approach, 
             which is new for version 4. In order to provide easier migration for sites using 
             version 3 of this API, you can also access some properties from the 
             HttpBrowserCapabilities object. For example, is this site being accessed with 
-            a mobile device? <strong><%= Request.Browser.IsMobileDevice ? "Yes" : "No" %></strong></p>
+            a mobile device? <strong><%: isMobileDeviceString %></strong></p>
         <table>
             <tr>
                 <th>Key</th>


### PR DESCRIPTION
Surround the call to `Request.Browser.IsMobileDevice` at [Cloud/Framework-Web/Default.aspx] with try/catch.

![image](https://github.com/51Degrees/device-detection-dotnet-examples/assets/5711520/30a71bbc-1dd7-48a8-a7ee-4a9edc728cf7)

Covers for potential vulnerability.

Initial exception screenshot:
![image (15)](https://github.com/51Degrees/device-detection-dotnet-examples/assets/5711520/5b3687b6-d3ef-4379-bf8d-02b8060b9838)

Related to changes in https://github.com/51Degrees/device-detection-dotnet-examples/pull/52 and https://github.com/51Degrees/pipeline-dotnet/pull/46
