### PR TITLE
Enable `Cloud/GettingStarted-Web` to display suppressed errors.

### DIFF
--- a/Examples/Cloud/GettingStarted-Web/Model/ErrorModel.cs
+++ b/Examples/Cloud/GettingStarted-Web/Model/ErrorModel.cs
@@ -20,12 +20,21 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
+using FiftyOne.Pipeline.Core.Data;
+
 namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedWeb.Model
 {
-    public class EvidenceModel
+    public class ErrorModel
     {
-        public string Key { get; init; }
-        public string Value { get; init; }
-        public bool? Used { get; init; }
+        public string TopClassName { get; private init; }
+        public string TopMessage { get; private init; }
+        public string ExceptionDump { get; private init; }
+
+        public ErrorModel(IFlowError flowError)
+        {
+            TopClassName = flowError.ExceptionData?.GetType().Name;
+            TopMessage = flowError.ExceptionData?.Message;
+            ExceptionDump = flowError.ExceptionData?.ToString();
+        }
     }
 }

--- a/Examples/Cloud/GettingStarted-Web/Model/IndexModel.cs
+++ b/Examples/Cloud/GettingStarted-Web/Model/IndexModel.cs
@@ -30,26 +30,28 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedWeb.Model
 {
     public class IndexModel
     {
-        public string HardwareVendor { get; private set; }
-        public string HardwareName { get; private set; }
-        public string DeviceType { get; private set; }
-        public string PlatformVendor { get; private set; }
-        public string PlatformName { get; private set; }
-        public string PlatformVersion { get; private set; }
-        public string BrowserVendor { get; private set; }
-        public string BrowserName { get; private set; }
-        public string BrowserVersion { get; private set; }
-        public string ScreenWidth { get; private set; }
-        public string ScreenHeight { get; private set; }
-        public string DeviceId { get; private set; }
+        public string HardwareVendor { get; private init; }
+        public string HardwareName { get; private init; }
+        public string DeviceType { get; private init; }
+        public string PlatformVendor { get; private init; }
+        public string PlatformName { get; private init; }
+        public string PlatformVersion { get; private init; }
+        public string BrowserVendor { get; private init; }
+        public string BrowserName { get; private init; }
+        public string BrowserVersion { get; private init; }
+        public string ScreenWidth { get; private init; }
+        public string ScreenHeight { get; private init; }
+        public string DeviceId { get; private init; }
 
-        public IFlowData FlowData { get; private set; }
+        public IFlowData FlowData { get; private init; }
 
-        public CloudRequestEngine Engine { get; private set; }
+        public CloudRequestEngine Engine { get; private init; }
 
-        public List<EvidenceModel> Evidence { get; private set; }
+        public IEnumerable<EvidenceModel> Evidence { get; private init; }
 
-        public IHeaderDictionary ResponseHeaders { get; private set; }
+        public IEnumerable<ErrorModel> Errors { get; private init; }
+
+        public IHeaderDictionary ResponseHeaders { get; private init; }
 
         public IndexModel(IFlowData flowData, IHeaderDictionary responseHeaders)
         {
@@ -58,15 +60,30 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedWeb.Model
 
             // Get the cloud engine
             Engine = FlowData.Pipeline.GetElement<CloudRequestEngine>();
+
+            // Try get key filter
+            IEvidenceKeyFilter evidenceKeyFilter;
+            try
+            {
+                evidenceKeyFilter = Engine.EvidenceKeyFilter;
+            }
+            catch 
+            {
+                evidenceKeyFilter = null;
+            }
+
             // Get the evidence that was used when performing device detection.
             Evidence = FlowData.GetEvidence().AsDictionary()
                 .Select(e => new EvidenceModel()
                 {
                     Key = e.Key,
                     Value = e.Value.ToString(),
-                    Used = Engine.EvidenceKeyFilter.Include(e.Key)
+                    Used = evidenceKeyFilter?.Include(e.Key),
                 })
                 .ToList();
+
+            // Get errors
+            Errors = FlowData.Errors?.Select(flowError => new ErrorModel(flowError)).ToList();
 
             // Get the results of device detection.
             var deviceData = FlowData.Get<IDeviceData>();

--- a/Examples/Cloud/GettingStarted-Web/Views/Home/Index.cshtml
+++ b/Examples/Cloud/GettingStarted-Web/Views/Home/Index.cshtml
@@ -67,6 +67,29 @@
 </noscript>
 
 <div id="content">
+    @if (Model.Errors is not null)
+    {
+        <div id="errors">
+            <h3>Errors</h3>
+            <table>
+                <tr>
+                    <th>Top Type</th>
+                    <th>Top Message</th>
+                    <th>Exception Dump</th>
+                </tr>
+                @foreach (var entry in Model.Errors)
+                {
+                    <tr class="lightred">
+                        <td>@(entry.TopClassName)</td>
+                        <td>@(entry.TopMessage)</td>
+                        <td>@(entry.ExceptionDump)</td>
+                    </tr>
+                }
+            </table>
+        </div>
+        <br />
+    }
+
     <h3>Detection results</h3>
     <p>
         The following values are determined by sever-side device detection
@@ -94,7 +117,7 @@
 
     <div id="evidence">
         <h3>Evidence used</h3>
-        <p class="smaller">Evidence was <span class="lightgreen">used</span> / <span class="lightyellow">present</span> for detection</p>
+        <p class="smaller">Evidence was <span class="lightgreen">used</span> / <span class="lightyellow">present</span> / <span class="darkorange">unusable</span> for detection</p>
         <table>
             <tr>
                  <th>Key</th>
@@ -102,7 +125,7 @@
             </tr>
             @foreach (var entry in Model.Evidence)
             {
-                <tr class="@(entry.Used ? "lightgreen" : "lightyellow")">
+                <tr class="@(entry.Used is null ? "darkorange" : (entry.Used.Value ? "lightgreen" : "lightyellow"))">
                     <td><b>@(entry.Key)</b></td>
                     <td>@(entry.Value)</td>
                 </tr>

--- a/Examples/Cloud/GettingStarted-Web/appsettings_51.json
+++ b/Examples/Cloud/GettingStarted-Web/appsettings_51.json
@@ -31,6 +31,13 @@
     // Both these options default to true anyway.
     // They are specified here for illustrative purposes.
     "ClientSideEvidenceEnabled": true,
-    "UseAsyncScript": true
+    "UseAsyncScript": true,
+
+    "BuildParameters": {
+      //Suppress and log any exceptions thrown from within (Web)Pipeline.Process() method
+      //By default it is `false`, we recommend keeping it that way during testing, but
+      //set to `true` in production to avoid any possible service unavailability
+      "SuppressProcessExceptions": false
+    }
   }
 }

--- a/Examples/Cloud/GettingStarted-Web/wwwroot/css/site.css
+++ b/Examples/Cloud/GettingStarted-Web/wwwroot/css/site.css
@@ -19,6 +19,10 @@ td {
   padding: 5px;
 }
 
+tr.lightred {
+    vertical-align: top;
+}
+
 .lightred {
   background-color: lightpink;
 }
@@ -29,6 +33,10 @@ td {
 
 .lightgreen {
   background-color: lightgreen;
+}
+
+.darkorange {
+    background-color: darkorange;
 }
 
 .smaller {


### PR DESCRIPTION
### Changes

- Add `ErrorModel` class that extracts useful data from [[IFlowError](https://github.com/51Degrees/pipeline-dotnet/blob/main/FiftyOne.Pipeline.Core/Data/IFlowError.cs)].
- Replace `set` accessors on model classes with [[init](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/init)].
- Add "Errors" section to `Index.cshtml` -- reflects [[IFlowData.Errors](https://github.com/51Degrees/pipeline-dotnet/blob/main/FiftyOne.Pipeline.Core/Data/IFlowData.cs#L50)] content (if present).
- Add new (`darkorange` "unusable") color for evidence cells -- used when `EvidenceKeyFilter` is not available to differenciate "used"/"present" states.
- Copy `SuppressProcessExceptions: false` clause (with description) to `appsettings_51.json`.

### Related

- https://github.com/51Degrees/pipeline-dotnet/pull/134
- https://github.com/51Degrees/specifications/pull/10#pullrequestreview-2371749068
- https://github.com/51Degrees/pipeline-dotnet/issues/132

### Screenshots

Errors table:

![Screenshot 2024-10-16 124903](https://github.com/user-attachments/assets/45edcf62-3f23-42b9-b346-7acb02dff987)

New "unusable" color for "Evidence" cells:

![Screenshot 2024-10-16 124930](https://github.com/user-attachments/assets/14280c85-b6f8-440d-87fc-108fd47c43dd)
