### PR TITLE
update all example projects to target .NET 8

### DIFF
--- a/Examples/Cloud/Configurator-Console/Configurator-Console.csproj
+++ b/Examples/Cloud/Configurator-Console/Configurator-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>FiftyOne.DeviceDetection.Examples.Cloud.Configurator</RootNamespace>
     <AssemblyName>FiftyOne.DeviceDetection.Examples.Cloud.Configurator</AssemblyName>
     <Platforms>AnyCPU;x64;x86</Platforms>

--- a/Examples/Cloud/Configurator-Console/Configurator-Console.csproj
+++ b/Examples/Cloud/Configurator-Console/Configurator-Console.csproj
@@ -9,8 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Cloud/Framework-Web/Framework-Web.csproj
+++ b/Examples/Cloud/Framework-Web/Framework-Web.csproj
@@ -91,6 +91,12 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.16" />
+    <PackageReference Include="NUglify">
+      <Version>1.21.11</Version>
+    </PackageReference>
+    <PackageReference Include="Selenium.WebDriver">
+      <Version>4.27.0</Version>
+    </PackageReference>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Examples/Cloud/GetAllProperties-Console/GetAllProperties.csproj
+++ b/Examples/Cloud/GetAllProperties-Console/GetAllProperties.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>FiftyOne.DeviceDetection.Examples.Cloud.GetAllProperties</AssemblyName>
     <Platforms>AnyCPU;x86;x64</Platforms>
     <Configurations>Debug;Release;CoreRelease;CoreDebug</Configurations>

--- a/Examples/Cloud/GetAllProperties-Console/GetAllProperties.csproj
+++ b/Examples/Cloud/GetAllProperties-Console/GetAllProperties.csproj
@@ -58,6 +58,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\ExampleBase\FiftyOne.DeviceDetection.Examples.csproj" />
   </ItemGroup>
 

--- a/Examples/Cloud/GettingStarted-Console/GettingStarted-Console.csproj
+++ b/Examples/Cloud/GettingStarted-Console/GettingStarted-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <Configurations>Debug;Release;CoreRelease;CoreDebug</Configurations>
     <AssemblyName>FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedConsole</AssemblyName>

--- a/Examples/Cloud/GettingStarted-Console/GettingStarted-Console.csproj
+++ b/Examples/Cloud/GettingStarted-Console/GettingStarted-Console.csproj
@@ -68,9 +68,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Cloud/GettingStarted-Web-ClientOnly/GettingStarted-Web-ClientOnly.csproj
+++ b/Examples/Cloud/GettingStarted-Web-ClientOnly/GettingStarted-Web-ClientOnly.csproj
@@ -8,8 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.36" />
-    <PackageReference Include="NUglify" Version="1.20.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.11" />
+    <PackageReference Include="NUglify" Version="1.21.10" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Cloud/GettingStarted-Web-ClientOnly/GettingStarted-Web-ClientOnly.csproj
+++ b/Examples/Cloud/GettingStarted-Web-ClientOnly/GettingStarted-Web-ClientOnly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Platforms>AnyCPU;x64;x86</Platforms>

--- a/Examples/Cloud/GettingStarted-Web/GettingStarted-Web.csproj
+++ b/Examples/Cloud/GettingStarted-Web/GettingStarted-Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedWeb</AssemblyName>
     <RootNamespace>FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedWeb</RootNamespace>
     <Platforms>AnyCPU;x64;x86</Platforms>

--- a/Examples/Cloud/GettingStarted-Web/GettingStarted-Web.csproj
+++ b/Examples/Cloud/GettingStarted-Web/GettingStarted-Web.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="FiftyOne.DeviceDetection" Version="4.4.198" />
     <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.118" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.36" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/Cloud/Metadata-Console/Metadata-Console.csproj
+++ b/Examples/Cloud/Metadata-Console/Metadata-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Examples.Cloud.Metadata</AssemblyName>
     <RootNamespace>Examples.Cloud.Metadata</RootNamespace>
     <Platforms>AnyCPU;x64;x86</Platforms>

--- a/Examples/Cloud/Metadata-Console/Metadata-Console.csproj
+++ b/Examples/Cloud/Metadata-Console/Metadata-Console.csproj
@@ -13,7 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/Examples/Cloud/NativeModel-Console/NativeModelLookup-Console.csproj
+++ b/Examples/Cloud/NativeModel-Console/NativeModelLookup-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <Configurations>Debug;Release;CoreRelease;CoreDebug</Configurations>
     <AssemblyName>FiftyOne.DeviceDetection.Examples.Cloud.NativeModelLookup</AssemblyName>

--- a/Examples/Cloud/NativeModel-Console/NativeModelLookup-Console.csproj
+++ b/Examples/Cloud/NativeModel-Console/NativeModelLookup-Console.csproj
@@ -62,7 +62,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/Examples/Cloud/TAC-Console/TacLookup-Console.csproj
+++ b/Examples/Cloud/TAC-Console/TacLookup-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <Configurations>Debug;Release;CoreRelease;CoreDebug</Configurations>
     <AssemblyName>FiftyOne.DeviceDetection.Examples.Cloud.TacLookup</AssemblyName>

--- a/Examples/Cloud/TAC-Console/TacLookup-Console.csproj
+++ b/Examples/Cloud/TAC-Console/TacLookup-Console.csproj
@@ -68,9 +68,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/ExampleBase/FiftyOne.DeviceDetection.Examples.csproj
+++ b/Examples/ExampleBase/FiftyOne.DeviceDetection.Examples.csproj
@@ -11,6 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FiftyOne.DeviceDetection" Version="4.4.198" />
-		<PackageReference Include="YamlDotNet" Version="13.1.1" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+		<PackageReference Include="YamlDotNet" Version="16.2.1" />
 	</ItemGroup>
 </Project>

--- a/Examples/Legacy Web/Cloud-UACH-manual/Cloud - Client-Hints Not Integrated.csproj
+++ b/Examples/Legacy Web/Cloud-UACH-manual/Cloud - Client-Hints Not Integrated.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="FiftyOne.DeviceDetection" Version="4.4.198" />
     <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.118" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.11" />
   </ItemGroup>
   

--- a/Examples/Legacy Web/Cloud-UACH-manual/Cloud - Client-Hints Not Integrated.csproj
+++ b/Examples/Legacy Web/Cloud-UACH-manual/Cloud - Client-Hints Not Integrated.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <RootNamespace>Cloud_Cloud_Client_Hints_Not_Integrated</RootNamespace>
     <AssemblyName>Cloud_Cloud_Client_Hints_Not_Integrated</AssemblyName>

--- a/Examples/Legacy Web/Cloud-UACH/Cloud - Client-Hints.csproj
+++ b/Examples/Legacy Web/Cloud-UACH/Cloud - Client-Hints.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <RootNamespace>Cloud_Client_Hints_NetCore_31</RootNamespace>
     <AssemblyName>Cloud_Client_Hints_NetCore_31</AssemblyName>

--- a/Examples/Legacy Web/Cloud-UACH/Cloud - Client-Hints.csproj
+++ b/Examples/Legacy Web/Cloud-UACH/Cloud - Client-Hints.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="FiftyOne.DeviceDetection" Version="4.4.198" />
     <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.118" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.11" />
   </ItemGroup>
   

--- a/Examples/Legacy Web/UACH-manual/Client-Hints Not Integrated.csproj
+++ b/Examples/Legacy Web/UACH-manual/Client-Hints Not Integrated.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="FiftyOne.DeviceDetection" Version="4.4.198" />
     <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.118" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.11" />
   </ItemGroup>
   

--- a/Examples/Legacy Web/UACH-manual/Client-Hints Not Integrated.csproj
+++ b/Examples/Legacy Web/UACH-manual/Client-Hints Not Integrated.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <RootNamespace>Client_Hints_Not_Integrated_NetCore_31</RootNamespace>
     <AssemblyName>Client_Hints_Not_Integrated_NetCore_31</AssemblyName>

--- a/Examples/Legacy Web/UACH/Client-Hints.csproj
+++ b/Examples/Legacy Web/UACH/Client-Hints.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <RootNamespace>Client_Hints_NetCore_31</RootNamespace>
     <AssemblyName>Client_Hints_NetCore_31</AssemblyName>

--- a/Examples/Legacy Web/UACH/Client-Hints.csproj
+++ b/Examples/Legacy Web/UACH/Client-Hints.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="FiftyOne.DeviceDetection" Version="4.4.198" />
     <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.118" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.11" />
   </ItemGroup>
   

--- a/Examples/OnPremise/AppleServerSide-Console/AppleServerSide-Console.csproj
+++ b/Examples/OnPremise/AppleServerSide-Console/AppleServerSide-Console.csproj
@@ -8,8 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/OnPremise/AppleServerSide-Console/AppleServerSide-Console.csproj
+++ b/Examples/OnPremise/AppleServerSide-Console/AppleServerSide-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>AppleServerSide_Console</RootNamespace>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>

--- a/Examples/OnPremise/AppleServerSideConfig-Console/AppleServerSideConfig-Console.csproj
+++ b/Examples/OnPremise/AppleServerSideConfig-Console/AppleServerSideConfig-Console.csproj
@@ -18,9 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/OnPremise/AppleServerSideConfig-Console/AppleServerSideConfig-Console.csproj
+++ b/Examples/OnPremise/AppleServerSideConfig-Console/AppleServerSideConfig-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>AppleServerSide_Console</RootNamespace>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>

--- a/Examples/OnPremise/Framework-Web/Framework-Web.csproj
+++ b/Examples/OnPremise/Framework-Web/Framework-Web.csproj
@@ -126,6 +126,12 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.16" />
+    <PackageReference Include="NUglify">
+      <Version>1.21.11</Version>
+    </PackageReference>
+    <PackageReference Include="Selenium.WebDriver">
+      <Version>4.27.0</Version>
+    </PackageReference>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Examples/OnPremise/GettingStarted-Console/GettingStarted-Console.csproj
+++ b/Examples/OnPremise/GettingStarted-Console/GettingStarted-Console.csproj
@@ -19,7 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/Examples/OnPremise/GettingStarted-Console/GettingStarted-Console.csproj
+++ b/Examples/OnPremise/GettingStarted-Console/GettingStarted-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x86;x64</Platforms>
     <AssemblyName>FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedConsole</AssemblyName>
     <Configurations>Debug;Release;CoreRelease;CoreDebug</Configurations>

--- a/Examples/OnPremise/GettingStarted-Web/GettingStarted-Web.csproj
+++ b/Examples/OnPremise/GettingStarted-Web/GettingStarted-Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb</AssemblyName>
     <RootNamespace>FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb</RootNamespace>
     <Platforms>AnyCPU;x64;x86</Platforms>

--- a/Examples/OnPremise/GettingStarted-Web/GettingStarted-Web.csproj
+++ b/Examples/OnPremise/GettingStarted-Web/GettingStarted-Web.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="FiftyOne.DeviceDetection" Version="4.4.198" />
     <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.118" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.36" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/OnPremise/MatchMetrics-Console/MatchMetrics-Console.csproj
+++ b/Examples/OnPremise/MatchMetrics-Console/MatchMetrics-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>FiftyOne.DeviceDetection.Examples.OnPremise.MatchMetrics</RootNamespace>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <Configurations>Debug;Release;CoreRelease</Configurations>

--- a/Examples/OnPremise/MatchMetrics-Console/MatchMetrics-Console.csproj
+++ b/Examples/OnPremise/MatchMetrics-Console/MatchMetrics-Console.csproj
@@ -10,8 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/OnPremise/Metadata-Console/Metadata-Console.csproj
+++ b/Examples/OnPremise/Metadata-Console/Metadata-Console.csproj
@@ -12,7 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/Examples/OnPremise/Metadata-Console/Metadata-Console.csproj
+++ b/Examples/OnPremise/Metadata-Console/Metadata-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Examples.OnPremise.Metadata</AssemblyName>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>

--- a/Examples/OnPremise/OfflineProcessing-Console/OfflineProcessing-Console.csproj
+++ b/Examples/OnPremise/OfflineProcessing-Console/OfflineProcessing-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Examples.OnPremise.OfflineProcessing</AssemblyName>
     <RootNamespace>Examples.OnPremise.OfflineProcessing</RootNamespace>
     <Platforms>AnyCPU;x64;x86</Platforms>

--- a/Examples/OnPremise/OfflineProcessing-Console/OfflineProcessing-Console.csproj
+++ b/Examples/OnPremise/OfflineProcessing-Console/OfflineProcessing-Console.csproj
@@ -14,7 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/Examples/OnPremise/Performance-Console/Performance-Console.csproj
+++ b/Examples/OnPremise/Performance-Console/Performance-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>FiftyOne.DeviceDetection.Examples.OnPremise.Performance</RootNamespace>
     <AssemblyName>FiftyOne.DeviceDetection.Examples.OnPremise.Performance</AssemblyName>
     <Platforms>AnyCPU;x64;x86</Platforms>

--- a/Examples/OnPremise/Performance-Console/Performance-Console.csproj
+++ b/Examples/OnPremise/Performance-Console/Performance-Console.csproj
@@ -9,8 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/OnPremise/UpdateDataFile-Console/UpdateDataFile-Console.csproj
+++ b/Examples/OnPremise/UpdateDataFile-Console/UpdateDataFile-Console.csproj
@@ -10,8 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/OnPremise/UpdateDataFile-Console/UpdateDataFile-Console.csproj
+++ b/Examples/OnPremise/UpdateDataFile-Console/UpdateDataFile-Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>FiftyOne.DeviceDetection.Examples.OnPremise.UpdateDataFile</RootNamespace>
     <AssemblyName>FiftyOne.DeviceDetection.Examples.OnPremise.UpdateDataFile</AssemblyName>
     <Configurations>Debug;Release;CoreRelease</Configurations>

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Cloud/FiftyOne.DeviceDetection.Example.Tests.Cloud.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Cloud/FiftyOne.DeviceDetection.Example.Tests.Cloud.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Cloud/FiftyOne.DeviceDetection.Example.Tests.Cloud.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Cloud/FiftyOne.DeviceDetection.Example.Tests.Cloud.csproj
@@ -15,13 +15,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.OnPremise/FiftyOne.DeviceDetection.Example.Tests.OnPremise.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.OnPremise/FiftyOne.DeviceDetection.Example.Tests.OnPremise.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.OnPremise/FiftyOne.DeviceDetection.Example.Tests.OnPremise.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.OnPremise/FiftyOne.DeviceDetection.Example.Tests.OnPremise.csproj
@@ -14,13 +14,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.ClientOnly/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.ClientOnly.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.ClientOnly/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.ClientOnly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.ClientOnly/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.ClientOnly.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.ClientOnly/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.ClientOnly.csproj
@@ -11,14 +11,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.csproj
@@ -11,13 +11,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise.csproj
@@ -11,13 +11,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/FiftyOne.DeviceDetection.Example.Tests.Web.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/FiftyOne.DeviceDetection.Example.Tests.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -18,10 +18,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver" Version="4.14.1" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.5.3" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.9.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/FiftyOne.DeviceDetection.Example.Tests.Web.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/FiftyOne.DeviceDetection.Example.Tests.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU;x64;x86</Platforms>

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/Parameters.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/Parameters.cs
@@ -29,7 +29,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web
     public static class Parameters
     {
         public const string BASE_PROPERTIES = "HardwareVendor,HardwareName,DeviceType,PlatformVendor,PlatformName,PlatformVersion,BrowserVendor,BrowserName,BrowserVersion";
-        public const string ALL_PROPERTIES = null;
+        public const string ALL_PROPERTIES = "";
         public const string BROWSER_PROPERTIES = BASE_PROPERTIES + ",SetHeaderBrowserAccept-CH";
         public const string HARDWARE_PROPERTIES = BASE_PROPERTIES + ",SetHeaderHardwareAccept-CH";
         public const string PLATFORM_PROPERTIES = BASE_PROPERTIES + ",SetHeaderPlatformAccept-CH";

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/SeleniumTestsBase.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/SeleniumTestsBase.cs
@@ -31,7 +31,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DevToolsSessionDomains = OpenQA.Selenium.DevTools.DevToolsSessionDomains;
 // Used to map new version features.
-using Enhanced = OpenQA.Selenium.DevTools.V117;
+using Enhanced = OpenQA.Selenium.DevTools.V131;
 
 namespace FiftyOne.DeviceDetection.Example.Tests.Web
 {

--- a/ci/options.json
+++ b/ci/options.json
@@ -22,5 +22,13 @@
         "Arch": "x64",
         "BuildMethod": "dotnet",
         "PackageRequirement" : true
+    },
+    {
+        "Image": "macos-13",
+        "Name": "macos_x64_Release",
+        "Configuration": "CoreRelease",
+        "Arch": "x64",
+        "BuildMethod": "dotnet",
+        "PackageRequirement" : true
     }
 ]


### PR DESCRIPTION
Motivation:
1. .NET6 has reached its end of life and is no longer supported
2.  macos-13 runners do not have .NET6 installed (macos-12 runners are no longer provided)