### PR TITLE
FIX: treat logger as nullable

### DIFF
--- a/Examples/ExampleBase/ExampleBase.cs
+++ b/Examples/ExampleBase/ExampleBase.cs
@@ -129,7 +129,7 @@ namespace FiftyOne.DeviceDetection.Examples
                 // Remove null values
                 foreach(var keyWithNullValue in data.Where(kvp => kvp.Value is null).Select(kvp => kvp.Key).ToList())
                 {
-                    logger.LogWarning($"Document at offset {records-1} contains null value for key: '{keyWithNullValue}'!");
+                    logger?.LogWarning($"Document at offset {records-1} contains null value for key: '{keyWithNullValue}'!");    
                     data.Remove(keyWithNullValue);
                 }
 
@@ -139,7 +139,8 @@ namespace FiftyOne.DeviceDetection.Examples
                 }
                 else
                 {
-                    logger.LogWarning($"Document at offset {records - 1} contains no usable evidence!");
+                    
+                    logger?.LogWarning($"Document at offset {records - 1} contains no usable evidence!");
                     ++skipped;
                 }
 


### PR DESCRIPTION
Why? 

Performance tests were failing because of that: https://github.com/51Degrees/device-detection-dotnet/actions/runs/14608686262/job/40990562799#step:5:696