### PR TITLE
Add `-IncludePrerelease` switch

### DIFF
--- a/ci/update-packages.ps1
+++ b/ci/update-packages.ps1
@@ -6,6 +6,10 @@ param(
     [string]$RepoName
 )
 
-./dotnet/run-update-dependencies.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Name $Name
+./dotnet/run-update-dependencies.ps1 `
+    -IncludePrerelease `
+    -RepoName $RepoName `
+    -ProjectDir $ProjectDir `
+    -Name $Name
 
 exit $LASTEXITCODE


### PR DESCRIPTION
### Changes

- Add `-IncludePrerelease` switch to `update-packages.ps1`

### Why

- 🔴 https://github.com/51Degrees/device-detection-dotnet-examples/actions/runs/18400364969/job/52427992649#step:4:121
```
  NECESSARY UPDATES:
  {
    "/home/runner/work/device-detection-dotnet-examples/device-detection-dotnet-examples/common/device-detection-dotnet-examples/Examples/ExampleBase/FiftyOne.DeviceDetection.Examples.csproj": {
      "FiftyOne.DeviceDetection": {
        "netstandard2.0": {
          "Requested": "4.5.0-alpha.81",
          "Latest": "Not found at the sources"
        }
      }
    }
  }
```
Despite the docs stating
> _Use the `--outdated` option to find out if there are newer versions available of the packages you're using in your projects._
> _By default, `--outdated` lists the latest stable packages_ **unless the resolved version is also a prerelease version.**

the invocations seem to misehave
```pwsh
dotnet list Examples/ExampleBase/FiftyOne.DeviceDetection.Examples.csproj  package --format json --outdated --highest-patch
```
⬇️ 
```json
{ 
  "version": 1,
  "parameters": "--outdated--highest-patch",
  "sources": [
    "https://api.nuget.org/v3/index.json",
    "C:/Projects/nuget_LocalFeed",
    "C:/Program Files (x86)/Microsoft SDKs/NuGetPackages/",
    "https://nuget.pkg.github.com/51Degrees/index.json"
  ],
  "projects": [
    {
      "path": "C:/Projects/Work/device-detection-dotnet-examples/Examples/ExampleBase/FiftyOne.DeviceDetection.Examples.csproj",
      "frameworks": [
        {
          "framework": "netstandard2.0",
          "topLevelPackages": [
            {
              "id": "FiftyOne.DeviceDetection",
              "requestedVersion": "4.5.0-alpha.81",
              "resolvedVersion": "4.5.0-alpha.81",
              "latestVersion": "Not found at the sources"
            }
          ]
        }
      ]
    }
  ]
}
```
vs
```pwsh
dotnet list Examples/ExampleBase/FiftyOne.DeviceDetection.Examples.csproj  package --format json --outdated --highest-patch --include-prerelease
```
⬇️ 
```json
{
  "version": 1,
  "parameters": "--outdated --include-prerelease--highest-patch",
  "sources": [
    "https://api.nuget.org/v3/index.json",
    "C:/Projects/nuget_LocalFeed",
    "C:/Program Files (x86)/Microsoft SDKs/NuGetPackages/",
    "https://nuget.pkg.github.com/51Degrees/index.json"
  ],
  "projects": [
    {
      "path": "C:/Projects/Work/device-detection-dotnet-examples/Examples/ExampleBase/FiftyOne.DeviceDetection.Examples.csproj",
      "frameworks": [
        {
          "framework": "netstandard2.0",
          "topLevelPackages": [
            {
              "id": "FiftyOne.DeviceDetection",
              "requestedVersion": "4.5.0-alpha.81",
              "resolvedVersion": "4.5.0-alpha.81",
              "latestVersion": "4.5.0-alpha.189"
            }
          ]
        }
      ]
    }
  ]
}
```