### PR TITLE
unit tests: change filter from DLL to csproj

### DIFF
--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Cloud/FiftyOne.DeviceDetection.Example.Tests.Cloud.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Cloud/FiftyOne.DeviceDetection.Example.Tests.Cloud.csproj
@@ -11,7 +11,8 @@
 	
 	<DefineConstants>TRACE;NETCORE</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\test.runsettings</RunSettingsFilePath>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Cloud/TestExamples.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Cloud/TestExamples.cs
@@ -40,7 +40,6 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Cloud
     /// crashing or throwing any unhandled exceptions.
     /// </remarks>
     [TestClass]
-    [Timeout(120000)] // 2 minute timeout per test
     public class TestExamples
     {
         private string ResourceKey;

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.OnPremise/FiftyOne.DeviceDetection.Example.Tests.OnPremise.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.OnPremise/FiftyOne.DeviceDetection.Example.Tests.OnPremise.csproj
@@ -11,6 +11,7 @@
 	
 	<DefineConstants>TRACE;NETCORE</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.OnPremise/TestExamples.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.OnPremise/TestExamples.cs
@@ -37,7 +37,6 @@ namespace FiftyOne.DeviceDetection.Example.Tests.OnPremise
     /// crashing or throwing any unhandled exceptions.
     /// </remarks>
     [TestClass]
-    [Timeout(120000)] // 2 minute timeout per test
     public class TestExamples
     {
         private string LicenseKey;

--- a/Tests/test.runsettings
+++ b/Tests/test.runsettings
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <TestSessionTimeout>300000</TestSessionTimeout>
+  </RunConfiguration>
+  <MSTest>
+    <TestTimeout>60000</TestTimeout>
+  </MSTest>
+</RunSettings>


### PR DESCRIPTION
This will:
- Run dotnet test on project files instead of DLLs
- Make --blame-hang-timeout 5m actually work (kills stuck tests after 5 min)
- Match only Cloud and OnPremise test projects (excludes Web tests)