### PR TITLE
Align resource key and data file environment variables

### DIFF
--- a/Examples/Cloud/Configurator-Console/Program.cs
+++ b/Examples/Cloud/Configurator-Console/Program.cs
@@ -149,8 +149,11 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.Configurator
                             $"cloud service is accessed using a 'ResourceKey'. For more " +
                             $"information see " +
                             $"https://51degrees.com/documentation/_info__resource_keys.html. " +
-                            $"A resource key with the properties required by this example can be " +
-                            $"created for free at https://configure.51degrees.com/1QWJwHxl. " +
+                            $"A free resource key can be created at " +
+                            $"https://configure.51degrees.com/Wkqxf3Bs and populates the free " +
+                            $"properties. With a paid subscription, a key created at " +
+                            $"https://configure.51degrees.com/hYzn3TV3 includes all the " +
+                            $"properties used by this example. " +
                             $"Once complete, pass the key as a command line argument or " +
                             $"populate the environment variable mentioned at the start of this " +
                             $"message");

--- a/Examples/Cloud/Configurator-Console/Program.cs
+++ b/Examples/Cloud/Configurator-Console/Program.cs
@@ -169,8 +169,7 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.Configurator
             // Use the command line args to get the resource key if present.
             // Otherwise, get it from the environment variable.
             string resourceKey = args.Length > 0 ? args[0] :
-                Environment.GetEnvironmentVariable(
-                    ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+                ExampleUtils.GetResourceKeyFromEnv();
 
             Example.Run(resourceKey, Console.Out);
         }

--- a/Examples/Cloud/Framework-Web/App_Data/51Degrees.json
+++ b/Examples/Cloud/Framework-Web/App_Data/51Degrees.json
@@ -3,8 +3,10 @@
     "Elements": [
       {
         "BuilderName": "CloudRequestEngine",
-        // Obtain a resource key with the properties required to run this 
-        // example for free: https://configure.51degrees.com/1QWJwHxl
+        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs
+        // populates the free properties. A paid subscription key created at
+        // https://configure.51degrees.com/hYzn3TV3 includes all the properties
+        // used by this example.
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",
           "CloudRequestOrigin": "51Degrees.example.com",

--- a/Examples/Cloud/Framework-Web/Default.aspx.cs
+++ b/Examples/Cloud/Framework-Web/Default.aspx.cs
@@ -70,10 +70,11 @@ using System.Web.UI;
 /// For example, the CloudRequestEngineBuilder. The methods available on the builder are 
 /// the same as those that will be available in the configuration file. 
 /// 
-/// Note that you will need to create a 'resource key' using our 
-/// [configurator](https://configure.51degrees.com/1QWJwHxl) site in order to get this example to 
-/// work. The previous link will pre-populate the key with the properties that are used in this
-/// example.
+/// Note that you will need to create a 'resource key' using our
+/// [configurator](https://configure.51degrees.com/Wkqxf3Bs) site in order to get this example to
+/// work. The previous link will pre-populate a free key with the free properties. A key created
+/// at [this link](https://configure.51degrees.com/hYzn3TV3) with a paid subscription also
+/// includes the paid properties used by this example.
 /// See our [documentation](/documentation/4.5/_services__configurator.html) 
 /// for more detail on resource keys and the configurator site. Once created, the key will 
 /// need to be copied into the configuration file:

--- a/Examples/Cloud/GettingStarted-Console/Program.cs
+++ b/Examples/Cloud/GettingStarted-Console/Program.cs
@@ -196,8 +196,7 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedConsole
             // Use the command line args to get the resource key if present.
             // Otherwise, get it from the environment variable.
             string resourceKey = args.Length > 0 ? args[0] :
-                Environment.GetEnvironmentVariable(
-                    ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+                ExampleUtils.GetResourceKeyFromEnv();
 
             // Load the configuration file
             var config = new ConfigurationBuilder()

--- a/Examples/Cloud/GettingStarted-Console/Program.cs
+++ b/Examples/Cloud/GettingStarted-Console/Program.cs
@@ -69,15 +69,25 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedConsole
                 using (var pipeline = new FiftyOnePipelineBuilder(loggerFactory, serviceProvider)
                     .BuildFromConfiguration(pipelineOptions))
                 {
+                    // Track whether any of the requested properties are left
+                    // without a value.
+                    bool anyValueMissing = false;
                     // Carry out some sample detections
                     foreach (var values in ExampleUtils.EvidenceValues)
                     {
-                        AnalyseEvidence(values, pipeline, output);
+                        anyValueMissing |= AnalyseEvidence(values, pipeline, output);
+                    }
+                    // A missing value usually means the resource key does not
+                    // include the property, so show the common message
+                    // explaining how to get a key with more properties.
+                    if (anyValueMissing)
+                    {
+                        output.WriteLine(ExampleUtils.PRICING_MESSAGE);
                     }
                 }
             }
 
-            private void AnalyseEvidence(
+            private bool AnalyseEvidence(
                 Dictionary<string, object> evidence,
                 IPipeline pipeline,
                 TextWriter output)
@@ -119,16 +129,18 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedConsole
                     // See the property dictionary at
                     // https://51degrees.com/developers/property-dictionary
                     // for details of all available properties.
-                    OutputValue("Mobile Device", device.IsMobile, message);
-                    OutputValue("Platform Name", device.PlatformName, message);
-                    OutputValue("Platform Version", device.PlatformVersion, message);
-                    OutputValue("Browser Name", device.BrowserName, message);
-                    OutputValue("Browser Version", device.BrowserVersion, message);
+                    bool anyValueMissing = false;
+                    anyValueMissing |= OutputValue("Mobile Device", device.IsMobile, message);
+                    anyValueMissing |= OutputValue("Platform Name", device.PlatformName, message);
+                    anyValueMissing |= OutputValue("Platform Version", device.PlatformVersion, message);
+                    anyValueMissing |= OutputValue("Browser Name", device.BrowserName, message);
+                    anyValueMissing |= OutputValue("Browser Version", device.BrowserVersion, message);
                     output.WriteLine(message.ToString());
+                    return anyValueMissing;
                 }
             }
 
-            private void OutputValue(string name,
+            private bool OutputValue(string name,
                 IAspectPropertyValue value,
                 StringBuilder message)
             {
@@ -140,6 +152,9 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedConsole
                 message.AppendLine(value.HasValue ?
                     $"\t{name}: " + value.Value :
                     $"\t{name}: " + value.NoValueMessage);
+                // Tell the caller whether the property was left without a
+                // value.
+                return value.HasValue == false;
             }
 
             /// <summary>
@@ -178,8 +193,11 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedConsole
                             $"service is accessed using a 'ResourceKey'. For more information " +
                             $"see " +
                             $"https://51degrees.com/documentation/_info__resource_keys.html. " +
-                            $"A resource key with the properties required by this example can be " +
-                            $"created for free at https://configure.51degrees.com/1QWJwHxl. " +
+                            $"A free resource key can be created at " +
+                            $"https://configure.51degrees.com/Wkqxf3Bs and populates the free " +
+                            $"properties. With a paid subscription, a key created at " +
+                            $"https://configure.51degrees.com/hYzn3TV3 includes all the " +
+                            $"properties used by this example. " +
                             $"Once complete, populate the config file or environment variable " +
                             $"mentioned at the start of this message with the key.");
                     }

--- a/Examples/Cloud/GettingStarted-Console/appsettings.json
+++ b/Examples/Cloud/GettingStarted-Console/appsettings.json
@@ -5,8 +5,10 @@
     "Elements": [
       {
         "BuilderName": "CloudRequestEngine",
-        // Obtain a resource key with the properties required to run this 
-        // example for free: https://configure.51degrees.com/1QWJwHxl
+        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs
+        // populates the free properties. A paid subscription key created at
+        // https://configure.51degrees.com/hYzn3TV3 includes all the properties
+        // used by this example.
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",
           "CloudRequestOrigin": "51Degrees.example.com"

--- a/Examples/Cloud/GettingStarted-Web-ClientOnly/Pages/Model.cs
+++ b/Examples/Cloud/GettingStarted-Web-ClientOnly/Pages/Model.cs
@@ -47,8 +47,7 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedWeb.ClientOnly.P
 
         public Model()
         {
-            ResourceKey = Environment.GetEnvironmentVariable(
-                ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+            ResourceKey = ExampleUtils.GetResourceKeyFromEnv();
             var cloudEndPoint = Environment.GetEnvironmentVariable(
                 ExampleUtils.CLOUD_END_POINT_ENV_VAR);
             CloudEndPoint = cloudEndPoint == null ?

--- a/Examples/Cloud/GettingStarted-Web/Model/IndexModel.cs
+++ b/Examples/Cloud/GettingStarted-Web/Model/IndexModel.cs
@@ -44,6 +44,13 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedWeb.Model
         public string DeviceId { get; private set; }
         public string PriceBand { get; private set; }
 
+        /// <summary>
+        /// True if any of the properties displayed by this example did not
+        /// have a value. This usually means the resource key does not
+        /// include them.
+        /// </summary>
+        public bool AnyValueMissing { get; private set; }
+
         public IFlowData FlowData { get; private set; }
 
         public CloudRequestEngine Engine { get; private set; }
@@ -88,6 +95,17 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedWeb.Model
             ScreenHeight = deviceData.TryGetValue(d => d.ScreenPixelsHeight.GetHumanReadable());
             DeviceId = deviceData.TryGetValue(d => d.DeviceId.GetHumanReadable());
             PriceBand = deviceData.TryGetValue(d => d.PriceBand.GetHumanReadable());
+
+            // The helper functions above return a string starting with
+            // 'Unknown' when a property does not have a value. Track this so
+            // that the page can show a message about the properties included
+            // in the resource key being used.
+            AnyValueMissing = new[]
+            {
+                HardwareVendor, HardwareName, DeviceType, PlatformVendor,
+                PlatformName, PlatformVersion, BrowserVendor, BrowserName,
+                BrowserVersion, ScreenWidth, ScreenHeight, DeviceId, PriceBand
+            }.Any(v => v.StartsWith("Unknown ("));
         }
     }
 }

--- a/Examples/Cloud/GettingStarted-Web/Program.cs
+++ b/Examples/Cloud/GettingStarted-Web/Program.cs
@@ -137,8 +137,11 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedWeb
                         $"'{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud " +
                         $"service is accessed using a 'ResourceKey'. For more information " +
                         $"see https://51degrees.com/documentation/_info__resource_keys.html. " +
-                        $"A resource key with the properties required by this example can be " +
-                        $"created for free at https://configure.51degrees.com/1QWJwHxl. " +
+                        $"A free resource key can be created at " +
+                        $"https://configure.51degrees.com/Wkqxf3Bs and populates the free " +
+                        $"properties. With a paid subscription, a key created at " +
+                        $"https://configure.51degrees.com/hYzn3TV3 includes all the " +
+                        $"properties used by this example. " +
                         $"Once complete, populate the config file or environment variable " +
                         $"mentioned at the start of this message with the key.");
                 }

--- a/Examples/Cloud/GettingStarted-Web/Program.cs
+++ b/Examples/Cloud/GettingStarted-Web/Program.cs
@@ -123,8 +123,7 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedWeb
                 var resourceKeyConfigKey = $"PipelineOptions:Elements:{cloudEngineIndex}" +
                     $":BuildParameters:ResourceKey";
 
-                string resourceKey = Environment.GetEnvironmentVariable(
-                        ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+                string resourceKey = ExampleUtils.GetResourceKeyFromEnv();
 
                 if (string.IsNullOrEmpty(resourceKey) == false)
                 {

--- a/Examples/Cloud/GettingStarted-Web/Views/Home/Index.cshtml
+++ b/Examples/Cloud/GettingStarted-Web/Views/Home/Index.cshtml
@@ -91,6 +91,12 @@
         <tr class="lightyellow"><td><b>Device Id:</b></td><td> @Model.DeviceId</td></tr>
         <tr class="lightyellow"><td><b>Price Band:</b></td><td> @Model.PriceBand</td></tr>
     </table>
+    @if (Model.AnyValueMissing)
+    {
+        <div class="example-alert">
+            @ExampleUtils.PRICING_MESSAGE
+        </div>
+    }
     <br />
 
     <div id="evidence">

--- a/Examples/Cloud/GettingStarted-Web/appsettings_51.json
+++ b/Examples/Cloud/GettingStarted-Web/appsettings_51.json
@@ -5,8 +5,10 @@
     "Elements": [
       {
         "BuilderName": "CloudRequestEngine",
-        // Obtain a resource key with the properties required to run this 
-        // example for free: https://configure.51degrees.com/1QWJwHxl
+        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs
+        // populates the free properties. A paid subscription key created at
+        // https://configure.51degrees.com/hYzn3TV3 includes all the properties
+        // used by this example.
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",
           "CloudRequestOrigin": "51Degrees.example.com",

--- a/Examples/Cloud/Metadata-Console/Program.cs
+++ b/Examples/Cloud/Metadata-Console/Program.cs
@@ -144,8 +144,11 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.Metadata
                     $"'{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud service is " +
                     $"accessed using a 'ResourceKey'. For more information see " +
                     $"https://51degrees.com/documentation/_info__resource_keys.html. " +
-                    $"A resource key with the properties required by this example can be " +
-                    $"created for free at https://configure.51degrees.com/1QWJwHxl. " +
+                    $"A free resource key can be created at " +
+                    $"https://configure.51degrees.com/Wkqxf3Bs and populates the free " +
+                    $"properties. With a paid subscription, a key created at " +
+                    $"https://configure.51degrees.com/hYzn3TV3 includes all the " +
+                    $"properties used by this example. " +
                     $"Once complete, supply the resource key as a command line argument or via " +
                     $"the environment variable mentioned at the start of this message.");
             }

--- a/Examples/Cloud/Metadata-Console/Program.cs
+++ b/Examples/Cloud/Metadata-Console/Program.cs
@@ -131,8 +131,7 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.Metadata
             // Use the command line args to get the resource key if present.
             // Otherwise, get it from the environment variable.
             string resourceKey = args.Length > 0 ? args[0] :
-                Environment.GetEnvironmentVariable(
-                    ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+                ExampleUtils.GetResourceKeyFromEnv();
 
             // Configure a logger to output to the console.
             var loggerFactory = LoggerFactory.Create(b => b.AddConsole());

--- a/Examples/Cloud/NativeModel-Console/Program.cs
+++ b/Examples/Cloud/NativeModel-Console/Program.cs
@@ -139,8 +139,7 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.NativeModelLookup
             // Use the command line args to get the resource key if present.
             // Otherwise, get it from the environment variable.
             string resourceKey = args.Length > 0 ? args[0] :
-                Environment.GetEnvironmentVariable(
-                    ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+                ExampleUtils.GetResourceKeyFromEnv();
 
             // Configure a logger to output to the console.
             var loggerFactory = LoggerFactory.Create(b => b.AddConsole());

--- a/Examples/Cloud/NativeModel-Console/Program.cs
+++ b/Examples/Cloud/NativeModel-Console/Program.cs
@@ -152,11 +152,11 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.NativeModelLookup
                     $"The 51Degrees cloud service is accessed using a 'ResourceKey'. " +
                     $"For more information " +
                     $"see https://51degrees.com/documentation/_info__resource_keys.html. " +
-                    $"Native model lookup is not available as a free service. This means that " +
-                    $"you will first need a license key, which can be purchased from our " +
-                    $"pricing page: https://51degrees.com/pricing. Once this is done, a resource " +
+                    $"Native model lookup requires a paid subscription. See " +
+                    $"https://51degrees.com/pricing to get a paid subscription with more " +
+                    $"properties. Once subscribed, a resource " +
                     $"key with the properties required by this example can be created at " +
-                    $"https://configure.51degrees.com/QKyYH5XT. You can now populate the " +
+                    $"https://configure.51degrees.com/hYzn3TV3. You can now populate the " +
                     $"environment variable mentioned at the start of this message with the " +
                     $"resource key or pass it as the first argument on the command line.");
             }

--- a/Examples/Cloud/TAC-Console/Program.cs
+++ b/Examples/Cloud/TAC-Console/Program.cs
@@ -171,8 +171,7 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.TacLookup
             // Use the command line args to get the resource key if present.
             // Otherwise, get it from the environment variable.
             string resourceKey = args.Length > 0 ? args[0] :
-                Environment.GetEnvironmentVariable(
-                    ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+                ExampleUtils.GetResourceKeyFromEnv();
 
             // Load the configuration file
             var config = new ConfigurationBuilder()

--- a/Examples/Cloud/TAC-Console/Program.cs
+++ b/Examples/Cloud/TAC-Console/Program.cs
@@ -149,11 +149,11 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.TacLookup
                             $"The 51Degrees cloud service is accessed using a 'ResourceKey'. " +
                             $"For more information see " +
                             $"https://51degrees.com/documentation/_info__resource_keys.html. " +
-                            $"TAC lookup is not available as a free service. This means " +
-                            $"that you will first need a license key, which can be purchased " +
-                            $"from our pricing page: https://51degrees.com/pricing. Once this is " +
-                            $"done, a resource key with the properties required by this example " +
-                            $"can be created at https://configure.51degrees.com/QKyYH5XT. You " +
+                            $"TAC lookup requires a paid subscription. See " +
+                            $"https://51degrees.com/pricing to get a paid subscription with " +
+                            $"more properties. Once subscribed, a resource key with the " +
+                            $"properties required by this example " +
+                            $"can be created at https://configure.51degrees.com/hYzn3TV3. You " +
                             $"can now populate the environment variable mentioned at the start " +
                             $"of this message with the resource key or pass it as the first " +
                             $"argument on the command line.");

--- a/Examples/Cloud/TAC-Console/appsettings.json
+++ b/Examples/Cloud/TAC-Console/appsettings.json
@@ -5,9 +5,10 @@
     "Elements": [
       {
         "BuilderName": "CloudRequestEngine",
-        // TAC lookup requires a license key, which can be purchased from our pricing page:
-        // https://51degrees.com/pricing. You can then obtain a resource key with the properties
-        // required to run this example here: https://configure.51degrees.com/QKyYH5XT
+        // TAC lookup requires a paid subscription. See https://51degrees.com/pricing
+        // to get a paid subscription with more properties. Once subscribed, a resource
+        // key with the properties required by this example can be created at
+        // https://configure.51degrees.com/hYzn3TV3
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",
           // Update this with your domain name.

--- a/Examples/ExampleBase/Constants.cs
+++ b/Examples/ExampleBase/Constants.cs
@@ -48,9 +48,19 @@ namespace FiftyOne.DeviceDetection.Examples
         public const string LICENSE_KEY_ENV_VAR = "DEVICEDETECTIONLICENSEKEY_DOTNET";
 
         /// <summary>
-        /// Environment variable key for the data file to use for the tests.
+        /// Environment variable key used to supply an explicit path to the
+        /// device detection data file. This aligned name is checked first,
+        /// before any legacy variable names.
         /// </summary>
-        public const string DEVICE_DETECTION_DATA_FILE_ENV_VAR = "DEVICEDETECTIONDATAFILE";
+        public const string DEVICE_DETECTION_DATA_FILE_ENV_VAR = "51DEGREES_DD_PATH";
+
+        /// <summary>
+        /// Legacy environment variable key used to supply an explicit path to
+        /// the device detection data file. Retained for backwards
+        /// compatibility and checked when
+        /// <see cref="DEVICE_DETECTION_DATA_FILE_ENV_VAR"/> is not set.
+        /// </summary>
+        public const string LEGACY_DEVICE_DETECTION_DATA_FILE_ENV_VAR = "DEVICEDETECTIONDATAFILE";
 
         /// <summary>
         /// Environment variable key for the evidence file to use for the tests.

--- a/Examples/ExampleBase/ExampleUtils.cs
+++ b/Examples/ExampleBase/ExampleUtils.cs
@@ -57,6 +57,15 @@ namespace FiftyOne.DeviceDetection.Examples
         /// </summary>
         public const string CLOUD_END_POINT_ENV_VAR = "51D_CLOUD_ENDPOINT";
 
+        /// <summary>
+        /// Message displayed when a resource key leaves some of the
+        /// properties used by an example without values.
+        /// </summary>
+        public const string PRICING_MESSAGE =
+            "Some properties used by this example are not available " +
+            "with a free resource key. See https://51degrees.com/pricing " +
+            "to get a paid subscription with more properties.";
+
 
         /// <summary>
         /// If data file is older than this number of days then a warning will be displayed.

--- a/Examples/ExampleBase/ExampleUtils.cs
+++ b/Examples/ExampleBase/ExampleUtils.cs
@@ -36,10 +36,19 @@ namespace FiftyOne.DeviceDetection.Examples
     public static class ExampleUtils
     {
         /// <summary>
-        /// The default environment variable key used to get the resource key 
-        /// to use when running cloud examples.
+        /// The default environment variable key used to get the resource key
+        /// to use when running cloud examples. This aligned name is checked
+        /// first, before any legacy variable names.
         /// </summary>
-        public const string CLOUD_RESOURCE_KEY_ENV_VAR = "SUPER_RESOURCE_KEY";
+        public const string CLOUD_RESOURCE_KEY_ENV_VAR = "51DEGREES_RESOURCE_KEY";
+
+        /// <summary>
+        /// The legacy environment variable key used to get the resource key
+        /// to use when running cloud examples. Retained for backwards
+        /// compatibility and checked when <see cref="CLOUD_RESOURCE_KEY_ENV_VAR"/>
+        /// is not set.
+        /// </summary>
+        public const string LEGACY_CLOUD_RESOURCE_KEY_ENV_VAR = "SUPER_RESOURCE_KEY";
 
         /// <summary>
         /// The default environment variable key used to get the end point URL
@@ -155,6 +164,44 @@ namespace FiftyOne.DeviceDetection.Examples
             DirectoryInfo dir = null)
         {
             return FileUtils.FindFile(filename, dir);
+        }
+
+        /// <summary>
+        /// Get the path to a device detection data file. The environment
+        /// variables are checked first for an explicit path. The aligned
+        /// variable named by <see cref="Constants.DEVICE_DETECTION_DATA_FILE_ENV_VAR"/>
+        /// takes precedence over the legacy variable named by
+        /// <see cref="Constants.LEGACY_DEVICE_DETECTION_DATA_FILE_ENV_VAR"/>.
+        /// If neither is set, the folder hierarchy is searched for the
+        /// supplied file name using <see cref="FindFile(string, DirectoryInfo)"/>.
+        /// </summary>
+        /// <param name="filename">
+        /// The data file name to search for when no environment variable
+        /// supplies an explicit path.
+        /// </param>
+        /// <param name="dir">
+        /// The directory to start searching from. If not provided the current
+        /// directory is used.
+        /// </param>
+        /// <returns>
+        /// The path to the data file, or null if no file could be found.
+        /// </returns>
+        public static string FindDataFile(
+            string filename,
+            DirectoryInfo dir = null)
+        {
+            var path = Environment.GetEnvironmentVariable(
+                Constants.DEVICE_DETECTION_DATA_FILE_ENV_VAR);
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                path = Environment.GetEnvironmentVariable(
+                    Constants.LEGACY_DEVICE_DETECTION_DATA_FILE_ENV_VAR);
+            }
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                path = FindFile(filename, dir);
+            }
+            return path;
         }
 
 
@@ -396,6 +443,39 @@ namespace FiftyOne.DeviceDetection.Examples
             {
                 setValue(string.Empty);
             }
+        }
+
+        /// <summary>
+        /// Get the resource key from the environment. The aligned
+        /// '51DEGREES_RESOURCE_KEY' variable is checked first, followed by
+        /// the legacy 'SUPER_RESOURCE_KEY' variable.
+        /// </summary>
+        /// <returns>
+        /// The resource key, or null if neither environment variable is set.
+        /// </returns>
+        public static string GetResourceKeyFromEnv()
+        {
+            var key = Environment.GetEnvironmentVariable(
+                CLOUD_RESOURCE_KEY_ENV_VAR);
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                key = Environment.GetEnvironmentVariable(
+                    LEGACY_CLOUD_RESOURCE_KEY_ENV_VAR);
+            }
+            return key;
+        }
+
+        /// <summary>
+        /// Get the resource key from the environment and run the action with
+        /// the value, or an empty string if no resource key is set. The
+        /// aligned '51DEGREES_RESOURCE_KEY' variable is checked first,
+        /// followed by the legacy 'SUPER_RESOURCE_KEY' variable.
+        /// </summary>
+        /// <param name="setValue"></param>
+        public static void GetResourceKeyFromEnv(Action<string> setValue)
+        {
+            var key = GetResourceKeyFromEnv();
+            setValue(string.IsNullOrWhiteSpace(key) ? string.Empty : key);
         }
     }
 }

--- a/Examples/Legacy Web/Cloud-UACH-manual/Startup.cs
+++ b/Examples/Legacy Web/Cloud-UACH-manual/Startup.cs
@@ -49,7 +49,7 @@ using Microsoft.Extensions.DependencyInjection;
 /// properties you are interested in as well as any associated license keys 
 /// that entitle you to increased request limits and/or paid-for properties.
 /// 
-/// You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com/X9F2f6Zm).
+/// You can create a free resource key using the 51Degrees [Configurator](https://configure.51degrees.com/Wkqxf3Bs).
 /// The properties used in this example are:
 ///   HardwareVendor, HardwareName, DeviceType
 ///   PlatformVendor, PlatformName, PlatformVersion
@@ -217,7 +217,7 @@ namespace Cloud_Client_Hints_Not_Integrated
                      resourceKey.ToString().StartsWith("!!")))
                 {
                     throw new Exception("You need to create a resource key at " +
-                        "https://configure.51degrees.com/X9F2f6Zm and paste " +
+                        "https://configure.51degrees.com/Wkqxf3Bs and paste " +
                         "it into the appsettings.json file in this example.");
                 }
             }

--- a/Examples/Legacy Web/Cloud-UACH-manual/appsettings.json
+++ b/Examples/Legacy Web/Cloud-UACH-manual/appsettings.json
@@ -11,8 +11,10 @@
     "Elements": [
       {
         "BuilderName": "CloudRequestEngine",
-        // Obtain a resource key with the properties required to test this 
-        // example for free: https://configure.51degrees.com/X9F2f6Zm      
+        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs
+        // populates the free properties. A paid subscription key created at
+        // https://configure.51degrees.com/hYzn3TV3 includes all the properties
+        // used by this example.
         // The properties used in this example are:
         //   HardwareVendor, HardwareName, DeviceType
         //   PlatformVendor, PlatformName, PlatformVersion

--- a/Examples/Legacy Web/Cloud-UACH/Startup.cs
+++ b/Examples/Legacy Web/Cloud-UACH/Startup.cs
@@ -44,7 +44,7 @@ using Microsoft.Extensions.DependencyInjection;
 /// properties you are interested in as well as any associated license keys 
 /// that entitle you to increased request limits and/or paid-for properties.
 /// 
-/// You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com/X9F2f6Zm).
+/// You can create a free resource key using the 51Degrees [Configurator](https://configure.51degrees.com/Wkqxf3Bs).
 /// The properties used in this example are:
 ///   HardwareVendor, HardwareName, DeviceType
 ///   PlatformVendor, PlatformName, PlatformVersion
@@ -210,7 +210,7 @@ namespace Cloud_Client_Hints
                      resourceKey.ToString().StartsWith("!!")))
                 {
                     throw new Exception("You need to create a resource key at " +
-                        "https://configure.51degrees.com/X9F2f6Zm and paste " +
+                        "https://configure.51degrees.com/Wkqxf3Bs and paste " +
                         "it into the appsettings.json file in this example.");
                 }
             }

--- a/Examples/Legacy Web/Cloud-UACH/appsettings.json
+++ b/Examples/Legacy Web/Cloud-UACH/appsettings.json
@@ -11,8 +11,10 @@
     "Elements": [
       {
         "BuilderName": "CloudRequestEngine",
-        // Obtain a resource key with the properties required to test this 
-        // example for free: https://configure.51degrees.com/X9F2f6Zm      
+        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs
+        // populates the free properties. A paid subscription key created at
+        // https://configure.51degrees.com/hYzn3TV3 includes all the properties
+        // used by this example.
         // The properties used in this example are:
         //   HardwareVendor, HardwareName, DeviceType
         //   PlatformVendor, PlatformName, PlatformVersion

--- a/Examples/OnPremise/Framework-Web/Global.asax.cs
+++ b/Examples/OnPremise/Framework-Web/Global.asax.cs
@@ -37,7 +37,7 @@ namespace Framework_Web
         {
             // Modify the configuration to a full path to the data file if the standard example is being used.
             var configFile = new FileInfo(HttpContext.Current.Server.MapPath("~/App_Data/51Degrees.json"));
-            var fullPath = ExampleUtils.FindFile("51Degrees-LiteV4.1.hash", configFile.Directory);
+            var fullPath = ExampleUtils.FindDataFile("51Degrees-LiteV4.1.hash", configFile.Directory);
             if (String.IsNullOrEmpty(fullPath) == false)
             {
                 var config = File.ReadAllText(configFile.FullName);

--- a/Examples/OnPremise/GettingStarted-Console/Program.cs
+++ b/Examples/OnPremise/GettingStarted-Console/Program.cs
@@ -183,7 +183,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedConsole
                 // Note that the Lite data file is only used for illustration, and has limited accuracy
                 // and capabilities. Find out about the Enterprise data file on our pricing page:
                 // https://51degrees.com/pricing
-                ExampleUtils.FindFile(Constants.LITE_HASH_DATA_FILE_NAME);
+                ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
 
             // Configure a logger to output to the console.
             var loggerFactory = LoggerFactory.Create(b => b.AddConsole());

--- a/Examples/OnPremise/GettingStarted-Web/Program.cs
+++ b/Examples/OnPremise/GettingStarted-Web/Program.cs
@@ -110,11 +110,27 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb
             var dataFileConfigKey = $"PipelineOptions:Elements:{hashEngineIndex}" +
                 $":BuildParameters:DataFile";
 
-            var dataFile = options.GetHashDataFile();
+            // An explicit data file path supplied in an environment variable takes
+            // precedence over the value in the configuration file. The aligned
+            // '51DEGREES_DD_PATH' variable is checked first, followed by the legacy
+            // 'DEVICEDETECTIONDATAFILE' variable.
+            var dataFile = Environment.GetEnvironmentVariable(
+                Constants.DEVICE_DETECTION_DATA_FILE_ENV_VAR);
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = Environment.GetEnvironmentVariable(
+                    Constants.LEGACY_DEVICE_DETECTION_DATA_FILE_ENV_VAR);
+            }
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = options.GetHashDataFile();
+            }
             var foundDataFile = false;
             if (string.IsNullOrEmpty(dataFile))
             {
-                throw new Exception($"A data file must be specified in the appsettings.json file.");
+                throw new Exception($"A data file must be specified in the " +
+                    $"appsettings.json file or the " +
+                    $"'{Constants.DEVICE_DETECTION_DATA_FILE_ENV_VAR}' environment variable.");
             }
             // The data file location provided in the configuration may be using an absolute or
             // relative path. If it is relative then search for a matching file using the 

--- a/Examples/OnPremise/MatchMetrics-Console/Program.cs
+++ b/Examples/OnPremise/MatchMetrics-Console/Program.cs
@@ -259,14 +259,18 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.MatchMetrics
 
             private string CheckDataFile(string dataFile)
             {
-                // No filename specified use the default
+                // No filename specified. Check the environment variables for an explicit
+                // path, then search the folder hierarchy for the default file name.
                 if (dataFile == null)
                 {
-                    dataFile = Constants.LITE_HASH_DATA_FILE_NAME;
-                    Logger.LogWarning($"No filename specified. Using default '{dataFile}'");
+                    Logger.LogWarning($"No filename specified. Checking the " +
+                        $"'{Constants.DEVICE_DETECTION_DATA_FILE_ENV_VAR}' environment " +
+                        $"variable, then searching for the default " +
+                        $"'{Constants.LITE_HASH_DATA_FILE_NAME}'");
+                    dataFile = ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
                 }
                 // Work out where the data file is if we don't have an absolute path.
-                if (dataFile != null && Path.IsPathRooted(dataFile) == false)
+                else if (Path.IsPathRooted(dataFile) == false)
                 {
                     dataFile = ExampleUtils.FindFile(dataFile);
                 }

--- a/Examples/OnPremise/Metadata-Console/Program.cs
+++ b/Examples/OnPremise/Metadata-Console/Program.cs
@@ -238,7 +238,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.Metadata
                 // Note that the Lite data file is only used for illustration, and has limited accuracy
                 // and capabilities. Find out about the Enterprise data file on our pricing page:
                 // https://51degrees.com/pricing
-                ExampleUtils.FindFile(Constants.LITE_HASH_DATA_FILE_NAME);
+                ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
 
             // Configure a logger to output to the console.
             var loggerFactory = LoggerFactory.Create(b => b.AddConsole());

--- a/Examples/OnPremise/OfflineProcessing-Console/Program.cs
+++ b/Examples/OnPremise/OfflineProcessing-Console/Program.cs
@@ -226,7 +226,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.OfflineProcessing
                 // Note that the Lite data file is only used for illustration, and has limited accuracy
                 // and capabilities. Find out about the Enterprise data file on our pricing page:
                 // https://51degrees.com/pricing
-                ExampleUtils.FindFile(Constants.LITE_HASH_DATA_FILE_NAME);
+                ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
             // Do the same for the yaml evidence file.
             var evidenceFile = args.Length > 1 ? args[1] :
                 // This file contains the 20,000 most commonly seen combinations of header values 

--- a/Examples/OnPremise/Performance-Console/Program.cs
+++ b/Examples/OnPremise/Performance-Console/Program.cs
@@ -331,7 +331,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.Performance
                     // Note that the Lite data file is only used for illustration, and has limited accuracy
                     // and capabilities. Find out about the Enterprise data file on our pricing page:
                     // https://51degrees.com/pricing
-                    ExampleUtils.FindFile(Constants.LITE_HASH_DATA_FILE_NAME);
+                    ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
                 // Do the same for the yaml evidence file.
                 var evidenceFile = options.EvidenceFile != null ? options.EvidenceFile :
                     // This file contains the 20,000 most commonly seen combinations of header values 

--- a/Examples/OnPremise/UpdateDataFile-Console/Program.cs
+++ b/Examples/OnPremise/UpdateDataFile-Console/Program.cs
@@ -364,11 +364,22 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.UpdateDataFile
 
             private string CheckDataFile(string dataFile, ILogger logger)
             {
-                // No filename specified use the default
+                // No filename specified. Check the environment variables for an explicit
+                // path before falling back to the default file name.
                 if (dataFile == null)
                 {
-                    dataFile = Constants.ENTERPRISE_HASH_DATA_FILE_NAME;
-                    logger.LogWarning($"No filename specified. Using default '{dataFile}'");
+                    dataFile = Environment.GetEnvironmentVariable(
+                        Constants.DEVICE_DETECTION_DATA_FILE_ENV_VAR);
+                    if (string.IsNullOrWhiteSpace(dataFile))
+                    {
+                        dataFile = Environment.GetEnvironmentVariable(
+                            Constants.LEGACY_DEVICE_DETECTION_DATA_FILE_ENV_VAR);
+                    }
+                    if (string.IsNullOrWhiteSpace(dataFile))
+                    {
+                        dataFile = Constants.ENTERPRISE_HASH_DATA_FILE_NAME;
+                        logger.LogWarning($"No filename specified. Using default '{dataFile}'");
+                    }
                 }
                 // Work out where the data file is if we don't have an absolute path.
                 if (dataFile != null && Path.IsPathRooted(dataFile) == false)

--- a/README.md
+++ b/README.md
@@ -11,15 +11,37 @@ their applications.
 
 ## Cloud resource keys
 
-A resource key configured with the properties needed to run most of the examples
-can be obtained [here](https://configure.51degrees.com/jqz435Nc). To use the
-resource key in the example it can be supplied as an environment variable called
-"51DEGREES_RESOURCE_KEY". The legacy environment variable name
+The cloud property tiers changed in May 2026. The examples and this
+documentation now reflect what is free and what needs a paid subscription.
+
+A free resource key that selects the free tier properties can be created
+[here](https://configure.51degrees.com/Wkqxf3Bs). A resource key that also
+includes the paid properties used by the examples can be created
+[here](https://configure.51degrees.com/hYzn3TV3). See
+https://51degrees.com/pricing to get a paid subscription with more properties.
+
+Of the properties the examples display, the free tier includes:
+
+- IsMobile, DeviceType, IsCrawler, DeviceId, UserAgents
+- ScreenPixelsWidth, ScreenPixelsHeight, ScreenPixelsHeightJavaScript
+- The three SetHeader*Accept-CH properties
+- JavascriptGetHighEntropyValues
+
+A paid subscription is needed for:
+
+- HardwareVendor, HardwareName, HardwareModel
+- PlatformVendor, PlatformName, PlatformVersion
+- BrowserVendor, BrowserName, BrowserVersion
+- ScreenPixelsWidthJavaScript, JavascriptHardwareProfile, Promise, Fetch,
+  PriceBand
+- The TAC and native model hardware profile properties
+
+To use the resource key in the example it can be supplied as an environment
+variable called "51DEGREES_RESOURCE_KEY". The legacy environment variable name
 "SUPER_RESOURCE_KEY" is still supported, with the aligned "51DEGREES_RESOURCE_KEY"
 name checked first.
 
-Some cloud examples require an enhanced resource key containing a license key.
-And some on-premise examples require you to provide a license key. You can find
+Some on-premise examples require you to provide a license key. You can find
 out about resource keys and license keys at our [pricing
 page](https://51degrees.com/pricing).
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,32 @@ their applications.
 A resource key configured with the properties needed to run most of the examples
 can be obtained [here](https://configure.51degrees.com/jqz435Nc). To use the
 resource key in the example it can be supplied as an environment variable called
-"SUPER_RESOURCE_KEY".
+"51DEGREES_RESOURCE_KEY". The legacy environment variable name
+"SUPER_RESOURCE_KEY" is still supported, with the aligned "51DEGREES_RESOURCE_KEY"
+name checked first.
 
 Some cloud examples require an enhanced resource key containing a license key.
 And some on-premise examples require you to provide a license key. You can find
 out about resource keys and license keys at our [pricing
 page](https://51degrees.com/pricing).
+
+## On-premise data file
+
+The on-premise examples need a device detection data file. The examples locate
+the file in the following order:
+
+1. The "51DEGREES_DD_PATH" environment variable, which can be set to an
+   explicit path to the data file. The legacy "DEVICEDETECTIONDATAFILE"
+   environment variable is also still supported, and is checked after
+   "51DEGREES_DD_PATH".
+2. A search of the folder hierarchy, walking up from the working directory,
+   for the expected data file name.
+3. The free 'Lite' data file in its expected location, which is the
+   device-detection-data submodule of this repository.
+
+Note that the aligned variable names start with a digit, which POSIX shells
+do not accept in plain assignments. On Linux and macOS set them with the env
+command, for example `env 51DEGREES_RESOURCE_KEY=AAA dotnet run`.
 
 ## Running examples with changes to Pipeline packages
 

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Cloud/TestExamples.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Cloud/TestExamples.cs
@@ -54,8 +54,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Cloud
         [TestInitialize]
         public void Init()
         {
-            var resourceKey = Environment.GetEnvironmentVariable(
-                ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+            var resourceKey = ExampleUtils.GetResourceKeyFromEnv();
             ResourceKey = string.IsNullOrWhiteSpace(resourceKey) == false ?
                 resourceKey : "!!YOUR_RESOURCE_KEY!!";
 

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.OnPremise/TestExamples.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.OnPremise/TestExamples.cs
@@ -63,13 +63,8 @@ namespace FiftyOne.DeviceDetection.Example.Tests.OnPremise
                 licenseKey: "!!YOUR_LICENSE_KEY!!";
 
             // Set Device Data file
-            DataFile = Environment.GetEnvironmentVariable(
-                Constants.DEVICE_DETECTION_DATA_FILE_ENV_VAR);
-            if (string.IsNullOrWhiteSpace(DataFile))
-            {
-                DataFile = ExampleUtils.FindFile(
-                    Constants.LITE_HASH_DATA_FILE_NAME);
-            }
+            DataFile = ExampleUtils.FindDataFile(
+                Constants.LITE_HASH_DATA_FILE_NAME);
 
             // Set evidence file for offline processing example.
             EvidenceFile = Environment.GetEnvironmentVariable(

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud/Parameters.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud/Parameters.cs
@@ -51,15 +51,14 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web.Cloud
                 // BrowserVersion
                 // In addition, each key will need to have specific setup
                 // for the '*Accept-CH' properties:
-                // SUPER_RESOURCE_KEY - SetHeaderBrowserAccept-CH, 
-                //    SetHeaderHardwareAccept-CH, SetHeaderPlatformAccept-CH
+                // 51DEGREES_RESOURCE_KEY (or legacy SUPER_RESOURCE_KEY) -
+                //    SetHeaderBrowserAccept-CH, SetHeaderHardwareAccept-CH,
+                //    SetHeaderPlatformAccept-CH
                 // ACCEPTCH_BROWSER_KEY - SetHeaderBrowserAccept-CH only
                 // ACCEPTCH_HARDWARE_KEY - SetHeaderHardwareAccept-CH only
                 // ACCEPTCH_PLATFORM_KEY - SetHeaderPlatformAccept-CH only
                 // ACCEPTCH_NONE_KEY - No *Accept-CH properties.
-                ExampleUtils.GetKeyFromEnv(
-                    ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR,
-                    v => SUPER_KEY = v);
+                ExampleUtils.GetResourceKeyFromEnv(v => SUPER_KEY = v);
                 ExampleUtils.GetKeyFromEnv("RESOURCE_KEY_CLOUD_V5_BESPOKE", v => V5_BESPOKE_KEY = v);
                 ExampleUtils.GetKeyFromEnv("ACCEPTCH_BROWSER_KEY", v => BROWSER_KEY = v);
                 ExampleUtils.GetKeyFromEnv("ACCEPTCH_HARDWARE_KEY", v => HARDWARE_KEY = v);

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/ClientHintsTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/ClientHintsTest.cs
@@ -54,6 +54,12 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise
             ExampleUtils.GetKeyFromEnv(
                 Constants.DEVICE_DETECTION_DATA_FILE_ENV_VAR,
                 v => DataFilePath = v);
+            if (string.IsNullOrEmpty(DataFilePath))
+            {
+                ExampleUtils.GetKeyFromEnv(
+                    Constants.LEGACY_DEVICE_DETECTION_DATA_FILE_ENV_VAR,
+                    v => DataFilePath = v);
+            }
         }
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -65,7 +71,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise
                     "data file that is included with the source code. " +
                     "A paid-for data file can be obtained from " +
                     "https://51degrees.com/pricing You can then configure " +
-                    "the DEVICE_DETECTION_DATAFILE environment variable " +
+                    "the 51DEGREES_DD_PATH environment variable " +
                     "with the full path to the file.");
             }
 

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -27,6 +27,10 @@ dotnet dev-certs https
 
 $env:DEVICEDETECTIONDATAFILE = [IO.Path]::Combine($RepoPath, "device-detection-data", "TAC-HashV41.hash")
 $env:SUPER_RESOURCE_KEY = $Keys.TestResourceKey
+# Aligned environment variable names. These are checked first by the examples
+# and tests. The legacy names above are retained for backwards compatibility.
+${env:51DEGREES_DD_PATH} = [IO.Path]::Combine($RepoPath, "device-detection-data", "TAC-HashV41.hash")
+${env:51DEGREES_RESOURCE_KEY} = $Keys.TestResourceKey
 $env:DEVICEDETECTIONLICENSEKEY_DOTNET = $Keys.DeviceDetection
 $env:ACCEPTCH_BROWSER_KEY = $Keys.AcceptCHBrowserKey
 $env:ACCEPTCH_HARDWARE_KEY = $Keys.AcceptCHHardwareKey


### PR DESCRIPTION
## Summary

This change aligns the environment variable names used by the examples with the convention shared across 51Degrees repositories.

- The resource key is read from `51DEGREES_RESOURCE_KEY` first. The legacy `SUPER_RESOURCE_KEY` name is retained and checked second, so existing setups keep working.
- An explicit data file path can be supplied in `51DEGREES_DD_PATH`, which is checked first. The legacy `DEVICEDETECTIONDATAFILE` name is retained and checked second. When neither is set the folder hierarchy is walked to find the expected file name, with the free Lite data file in the device-detection-data submodule as the final fallback.
- Developer-facing messages now reference the aligned names and the README documents the resolution order.
- The CI setup script also sets the aligned names, with the legacy assignments retained.

## Notes

- GitHub workflow secret references are unchanged. An accompanying issue advises on the aligned secret naming.
- The aligned names start with a digit, which POSIX shells do not accept in plain assignments. On Linux and macOS set them with the env command, for example `env 51DEGREES_RESOURCE_KEY=AAA dotnet run`.
