### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/Examples/Cloud/Configurator-Console/Program.cs
+++ b/Examples/Cloud/Configurator-Console/Program.cs
@@ -30,13 +30,13 @@ using System.Net.Http;
 using System.Text;
 
 /// <summary>
-/// This example is displayed at the end of the [Configurator](https://configure.51degrees.com/)
+/// This example is displayed at the end of the [Configurator](https://configure.51degrees.com/?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-cloud-configurator-console-program.cs&amp;utm_term=header)
 /// process, which is used to create resource keys for use with the 51Degrees cloud service.
 /// 
 /// It shows how to call the cloud with the newly created key and how to access the values 
 /// of the selected properties.
 ///
-/// See [Getting Started](https://51degrees.com/documentation/_examples__device_detection__getting_started__console__cloud.html)
+/// See [Getting Started](https://51degrees.com/documentation/_examples__device_detection__getting_started__console__cloud.html?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-cloud-configurator-console-program.cs&amp;utm_term=header)
 /// for a fuller example.
 /// 
 /// Required NuGet Dependencies:
@@ -148,11 +148,11 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.Configurator
                             $"variable '{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. The 51Degrees " +
                             $"cloud service is accessed using a 'ResourceKey'. For more " +
                             $"information see " +
-                            $"https://51degrees.com/documentation/_info__resource_keys.html. " +
+                            $"https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-configurator-console-program.cs&utm_term=resource-key-required. " +
                             $"A free resource key can be created at " +
-                            $"https://configure.51degrees.com/Wkqxf3Bs and populates the free " +
+                            $"https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-configurator-console-program.cs&utm_term=resource-key-required and populates the free " +
                             $"properties. With a paid subscription, a key created at " +
-                            $"https://configure.51degrees.com/hYzn3TV3 includes all the " +
+                            $"https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-configurator-console-program.cs&utm_term=resource-key-required includes all the " +
                             $"properties used by this example. " +
                             $"Once complete, pass the key as a command line argument or " +
                             $"populate the environment variable mentioned at the start of this " +

--- a/Examples/Cloud/Framework-Web/App_Data/51Degrees.json
+++ b/Examples/Cloud/Framework-Web/App_Data/51Degrees.json
@@ -3,9 +3,9 @@
     "Elements": [
       {
         "BuilderName": "CloudRequestEngine",
-        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs
+        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-framework-web-app_data-51degrees.json&utm_term=elements
         // populates the free properties. A paid subscription key created at
-        // https://configure.51degrees.com/hYzn3TV3 includes all the properties
+        // https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-framework-web-app_data-51degrees.json&utm_term=elements includes all the properties
         // used by this example.
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",

--- a/Examples/Cloud/Framework-Web/Default.aspx
+++ b/Examples/Cloud/Framework-Web/Default.aspx
@@ -222,7 +222,7 @@
                 WARNING: You are using the free 'Lite' data file. This does not include the client-side
                 evidence capabilities of the paid-for data file, so you will not see any additional
                 data below. Find out about the Enterprise data file on our
-                <a href="https://51degrees.com/pricing">pricing page</a>.
+                <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-cloud-framework-web-default.aspx&amp;utm_term=client-side-evidence-and-apple-models">pricing page</a>.
             </div>
         <% } %>
     </div>   

--- a/Examples/Cloud/Framework-Web/Default.aspx.cs
+++ b/Examples/Cloud/Framework-Web/Default.aspx.cs
@@ -71,9 +71,9 @@ using System.Web.UI;
 /// the same as those that will be available in the configuration file. 
 /// 
 /// Note that you will need to create a 'resource key' using our
-/// [configurator](https://configure.51degrees.com/Wkqxf3Bs) site in order to get this example to
+/// [configurator](https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-cloud-framework-web-default.aspx.cs&amp;utm_term=header) site in order to get this example to
 /// work. The previous link will pre-populate a free key with the free properties. A key created
-/// at [this link](https://configure.51degrees.com/hYzn3TV3) with a paid subscription also
+/// at [this link](https://configure.51degrees.com/hYzn3TV3?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-cloud-framework-web-default.aspx.cs&amp;utm_term=header) with a paid subscription also
 /// includes the paid properties used by this example.
 /// See our [documentation](/documentation/4.5/_services__configurator.html) 
 /// for more detail on resource keys and the configurator site. Once created, the key will 

--- a/Examples/Cloud/GetAllProperties-Console/Program.cs
+++ b/Examples/Cloud/GetAllProperties-Console/Program.cs
@@ -151,13 +151,13 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GetAllProperties
 
         static void Main(string[] args)
         {
-            // Obtain a resource key for free at https://configure.51degrees.com
+            // Obtain a resource key for free at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-getallproperties-console-program.cs&utm_term=main
             string resourceKey = "!!YOUR_RESOURCE_KEY!!";
 
             if (resourceKey.StartsWith("!!"))
             {
                 Console.WriteLine("You need to create a resource key at " +
-                    "https://configure.51degrees.com and paste it into the code, " +
+                    "https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-getallproperties-console-program.cs&utm_term=resource-key-required and paste it into the code, " +
                     "replacing !!YOUR_RESOURCE_KEY!!.");
                 Console.WriteLine("Make sure to include all the properties " +
                     "that you want to see displayed by this example.");

--- a/Examples/Cloud/GettingStarted-Console/Program.cs
+++ b/Examples/Cloud/GettingStarted-Console/Program.cs
@@ -63,7 +63,7 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedConsole
 
                 // In this example, we use the FiftyOnePipelineBuilder and configure it from a file.
                 // For more information about builders in general see the documentation at
-                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-gettingstarted-console-program.cs&utm_term=run
 
                 // Create the pipeline using the service provider and the configured options.
                 using (var pipeline = new FiftyOnePipelineBuilder(loggerFactory, serviceProvider)
@@ -127,7 +127,7 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedConsole
 
                     // Display the results of the detection, which are called device properties.
                     // See the property dictionary at
-                    // https://51degrees.com/developers/property-dictionary
+                    // https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-gettingstarted-console-program.cs&utm_term=run
                     // for details of all available properties.
                     bool anyValueMissing = false;
                     anyValueMissing |= OutputValue("Mobile Device", device.IsMobile, message);
@@ -192,11 +192,11 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedConsole
                             $"'{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud " +
                             $"service is accessed using a 'ResourceKey'. For more information " +
                             $"see " +
-                            $"https://51degrees.com/documentation/_info__resource_keys.html. " +
+                            $"https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-gettingstarted-console-program.cs&utm_term=resource-key-required. " +
                             $"A free resource key can be created at " +
-                            $"https://configure.51degrees.com/Wkqxf3Bs and populates the free " +
+                            $"https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-gettingstarted-console-program.cs&utm_term=resource-key-required and populates the free " +
                             $"properties. With a paid subscription, a key created at " +
-                            $"https://configure.51degrees.com/hYzn3TV3 includes all the " +
+                            $"https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-gettingstarted-console-program.cs&utm_term=resource-key-required includes all the " +
                             $"properties used by this example. " +
                             $"Once complete, populate the config file or environment variable " +
                             $"mentioned at the start of this message with the key.");

--- a/Examples/Cloud/GettingStarted-Console/appsettings.json
+++ b/Examples/Cloud/GettingStarted-Console/appsettings.json
@@ -5,9 +5,9 @@
     "Elements": [
       {
         "BuilderName": "CloudRequestEngine",
-        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs
+        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-gettingstarted-console-appsettings.json&utm_term=elements
         // populates the free properties. A paid subscription key created at
-        // https://configure.51degrees.com/hYzn3TV3 includes all the properties
+        // https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-gettingstarted-console-appsettings.json&utm_term=elements includes all the properties
         // used by this example.
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",

--- a/Examples/Cloud/GettingStarted-Web/Program.cs
+++ b/Examples/Cloud/GettingStarted-Web/Program.cs
@@ -136,11 +136,11 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.GettingStartedWeb
                         $"'appsettings.json' or the environment variable " +
                         $"'{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud " +
                         $"service is accessed using a 'ResourceKey'. For more information " +
-                        $"see https://51degrees.com/documentation/_info__resource_keys.html. " +
+                        $"see https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-gettingstarted-web-program.cs&utm_term=resource-key-required. " +
                         $"A free resource key can be created at " +
-                        $"https://configure.51degrees.com/Wkqxf3Bs and populates the free " +
+                        $"https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-gettingstarted-web-program.cs&utm_term=resource-key-required and populates the free " +
                         $"properties. With a paid subscription, a key created at " +
-                        $"https://configure.51degrees.com/hYzn3TV3 includes all the " +
+                        $"https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-gettingstarted-web-program.cs&utm_term=resource-key-required includes all the " +
                         $"properties used by this example. " +
                         $"Once complete, populate the config file or environment variable " +
                         $"mentioned at the start of this message with the key.");

--- a/Examples/Cloud/GettingStarted-Web/Views/Home/Index.cshtml
+++ b/Examples/Cloud/GettingStarted-Web/Views/Home/Index.cshtml
@@ -178,7 +178,7 @@
             WARNING: You are using the free 'Lite' data file. This does not include the client-side
             evidence capabilities of the paid-for data file, so you will not see any additional
             data below. Find out about the Enterprise data file on our
-            <a href="https://51degrees.com/pricing">pricing page</a>.
+            <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-cloud-gettingstarted-web-views-home-index.cshtml&amp;utm_term=client-side-evidence-and-apple-models">pricing page</a>.
         </div>
     }
 </div>

--- a/Examples/Cloud/GettingStarted-Web/appsettings_51.json
+++ b/Examples/Cloud/GettingStarted-Web/appsettings_51.json
@@ -5,9 +5,9 @@
     "Elements": [
       {
         "BuilderName": "CloudRequestEngine",
-        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs
+        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-gettingstarted-web-appsettings_51.json&utm_term=elements
         // populates the free properties. A paid subscription key created at
-        // https://configure.51degrees.com/hYzn3TV3 includes all the properties
+        // https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-gettingstarted-web-appsettings_51.json&utm_term=elements includes all the properties
         // used by this example.
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",

--- a/Examples/Cloud/Metadata-Console/Program.cs
+++ b/Examples/Cloud/Metadata-Console/Program.cs
@@ -143,11 +143,11 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.Metadata
                     $"'appsettings.json' or the environment variable " +
                     $"'{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud service is " +
                     $"accessed using a 'ResourceKey'. For more information see " +
-                    $"https://51degrees.com/documentation/_info__resource_keys.html. " +
+                    $"https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-metadata-console-program.cs&utm_term=resource-key-required. " +
                     $"A free resource key can be created at " +
-                    $"https://configure.51degrees.com/Wkqxf3Bs and populates the free " +
+                    $"https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-metadata-console-program.cs&utm_term=resource-key-required and populates the free " +
                     $"properties. With a paid subscription, a key created at " +
-                    $"https://configure.51degrees.com/hYzn3TV3 includes all the " +
+                    $"https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-metadata-console-program.cs&utm_term=resource-key-required includes all the " +
                     $"properties used by this example. " +
                     $"Once complete, supply the resource key as a command line argument or via " +
                     $"the environment variable mentioned at the start of this message.");

--- a/Examples/Cloud/NativeModel-Console/Program.cs
+++ b/Examples/Cloud/NativeModel-Console/Program.cs
@@ -75,7 +75,7 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.NativeModelLookup
                 // This example creates the pipeline and engines in code. For a demonstration
                 // of how to do this using a configuration file instead, see the TacLookup example.
                 // For more information about builders in general see the documentation at
-                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-nativemodel-console-program.cs&utm_term=run
                 var cloudRequestEngineBuilder = new CloudRequestEngineBuilder(loggerFactory, httpClient)
                     .SetResourceKey(resourceKey);
 
@@ -151,12 +151,12 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.NativeModelLookup
                     $"environment variable '{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. " +
                     $"The 51Degrees cloud service is accessed using a 'ResourceKey'. " +
                     $"For more information " +
-                    $"see https://51degrees.com/documentation/_info__resource_keys.html. " +
+                    $"see https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-nativemodel-console-program.cs&utm_term=resource-key-required. " +
                     $"Native model lookup requires a paid subscription. See " +
-                    $"https://51degrees.com/pricing to get a paid subscription with more " +
+                    $"https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-nativemodel-console-program.cs&utm_term=resource-key-required to get a paid subscription with more " +
                     $"properties. Once subscribed, a resource " +
                     $"key with the properties required by this example can be created at " +
-                    $"https://configure.51degrees.com/hYzn3TV3. You can now populate the " +
+                    $"https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-nativemodel-console-program.cs&utm_term=resource-key-required. You can now populate the " +
                     $"environment variable mentioned at the start of this message with the " +
                     $"resource key or pass it as the first argument on the command line.");
             }

--- a/Examples/Cloud/TAC-Console/Program.cs
+++ b/Examples/Cloud/TAC-Console/Program.cs
@@ -76,7 +76,7 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.TacLookup
                 // For a demonstration of how to do this in code instead, see the
                 // NativeModelLookup example.
                 // For more information about builders in general see the documentation at
-                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-tac-console-program.cs&utm_term=run
 
                 // Create the pipeline using the service provider and the configured options.
                 using (var pipeline = new FiftyOnePipelineBuilder(loggerFactory, serviceProvider)
@@ -148,12 +148,12 @@ namespace FiftyOne.DeviceDetection.Examples.Cloud.TacLookup
                             $"the environment variable '{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. " +
                             $"The 51Degrees cloud service is accessed using a 'ResourceKey'. " +
                             $"For more information see " +
-                            $"https://51degrees.com/documentation/_info__resource_keys.html. " +
+                            $"https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-tac-console-program.cs&utm_term=resource-key-required. " +
                             $"TAC lookup requires a paid subscription. See " +
-                            $"https://51degrees.com/pricing to get a paid subscription with " +
+                            $"https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-tac-console-program.cs&utm_term=resource-key-required to get a paid subscription with " +
                             $"more properties. Once subscribed, a resource key with the " +
                             $"properties required by this example " +
-                            $"can be created at https://configure.51degrees.com/hYzn3TV3. You " +
+                            $"can be created at https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-tac-console-program.cs&utm_term=resource-key-required. You " +
                             $"can now populate the environment variable mentioned at the start " +
                             $"of this message with the resource key or pass it as the first " +
                             $"argument on the command line.");

--- a/Examples/Cloud/TAC-Console/appsettings.json
+++ b/Examples/Cloud/TAC-Console/appsettings.json
@@ -5,10 +5,10 @@
     "Elements": [
       {
         "BuilderName": "CloudRequestEngine",
-        // TAC lookup requires a paid subscription. See https://51degrees.com/pricing
+        // TAC lookup requires a paid subscription. See https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-tac-console-appsettings.json&utm_term=elements
         // to get a paid subscription with more properties. Once subscribed, a resource
         // key with the properties required by this example can be created at
-        // https://configure.51degrees.com/hYzn3TV3
+        // https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-cloud-tac-console-appsettings.json&utm_term=elements
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",
           // Update this with your domain name.

--- a/Examples/ExampleBase/ExampleUtils.cs
+++ b/Examples/ExampleBase/ExampleUtils.cs
@@ -63,7 +63,7 @@ namespace FiftyOne.DeviceDetection.Examples
         /// </summary>
         public const string PRICING_MESSAGE =
             "Some properties used by this example are not available " +
-            "with a free resource key. See https://51degrees.com/pricing " +
+            "with a free resource key. See https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-examplebase-exampleutils.cs&utm_term=pricing_message " +
             "to get a paid subscription with more properties.";
 
 
@@ -310,14 +310,14 @@ namespace FiftyOne.DeviceDetection.Examples
                         $"data file is available from the device-detection-data repository on " +
                         $"GitHub https://github.com/51Degrees/device-detection-data. Find out " +
                         $"about the Enterprise data file, which includes automatic daily " +
-                        $"updates, on our pricing page: https://51degrees.com/pricing");
+                        $"updates, on our pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-examplebase-exampleutils.cs&utm_term=data-file-age-warning");
                 }
                 if (info.Tier == "Lite")
                 {
                     logger.LogWarning($"This example is using the 'Lite' data file. This is " +
                         $"used for illustration, and has limited accuracy and capabilities. " +
                         $"Find out about the Enterprise data file on our pricing page: " +
-                        $"https://51degrees.com/pricing");
+                        $"https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-examplebase-exampleutils.cs&utm_term=lite-data-file");
                 }
             }
         }
@@ -383,7 +383,7 @@ namespace FiftyOne.DeviceDetection.Examples
             //-
             //[getHighEntropyValues()](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues)
             //-
-            //[device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints)
+            //[device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-examplebase-exampleutils.cs&utm_term=evidencevalues)
             //- [OpenRTB 2.6
             //spec](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#objectuseragent)
 

--- a/Examples/Legacy Web/Cloud-UACH-manual/Startup.cs
+++ b/Examples/Legacy Web/Cloud-UACH-manual/Startup.cs
@@ -49,7 +49,7 @@ using Microsoft.Extensions.DependencyInjection;
 /// properties you are interested in as well as any associated license keys 
 /// that entitle you to increased request limits and/or paid-for properties.
 /// 
-/// You can create a free resource key using the 51Degrees [Configurator](https://configure.51degrees.com/Wkqxf3Bs).
+/// You can create a free resource key using the 51Degrees [Configurator](https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-legacy-web-cloud-uach-manual-startup.cs&amp;utm_term=header).
 /// The properties used in this example are:
 ///   HardwareVendor, HardwareName, DeviceType
 ///   PlatformVendor, PlatformName, PlatformVersion
@@ -217,7 +217,7 @@ namespace Cloud_Client_Hints_Not_Integrated
                      resourceKey.ToString().StartsWith("!!")))
                 {
                     throw new Exception("You need to create a resource key at " +
-                        "https://configure.51degrees.com/Wkqxf3Bs and paste " +
+                        "https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-legacy-web-cloud-uach-manual-startup.cs&utm_term=resource-key-required and paste " +
                         "it into the appsettings.json file in this example.");
                 }
             }

--- a/Examples/Legacy Web/Cloud-UACH-manual/appsettings.json
+++ b/Examples/Legacy Web/Cloud-UACH-manual/appsettings.json
@@ -11,9 +11,9 @@
     "Elements": [
       {
         "BuilderName": "CloudRequestEngine",
-        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs
+        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-legacy-web-cloud-uach-manual-appsettings.json&utm_term=elements
         // populates the free properties. A paid subscription key created at
-        // https://configure.51degrees.com/hYzn3TV3 includes all the properties
+        // https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-legacy-web-cloud-uach-manual-appsettings.json&utm_term=elements includes all the properties
         // used by this example.
         // The properties used in this example are:
         //   HardwareVendor, HardwareName, DeviceType

--- a/Examples/Legacy Web/Cloud-UACH/Startup.cs
+++ b/Examples/Legacy Web/Cloud-UACH/Startup.cs
@@ -44,7 +44,7 @@ using Microsoft.Extensions.DependencyInjection;
 /// properties you are interested in as well as any associated license keys 
 /// that entitle you to increased request limits and/or paid-for properties.
 /// 
-/// You can create a free resource key using the 51Degrees [Configurator](https://configure.51degrees.com/Wkqxf3Bs).
+/// You can create a free resource key using the 51Degrees [Configurator](https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-legacy-web-cloud-uach-startup.cs&amp;utm_term=header).
 /// The properties used in this example are:
 ///   HardwareVendor, HardwareName, DeviceType
 ///   PlatformVendor, PlatformName, PlatformVersion
@@ -210,7 +210,7 @@ namespace Cloud_Client_Hints
                      resourceKey.ToString().StartsWith("!!")))
                 {
                     throw new Exception("You need to create a resource key at " +
-                        "https://configure.51degrees.com/Wkqxf3Bs and paste " +
+                        "https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-legacy-web-cloud-uach-startup.cs&utm_term=resource-key-required and paste " +
                         "it into the appsettings.json file in this example.");
                 }
             }

--- a/Examples/Legacy Web/Cloud-UACH/appsettings.json
+++ b/Examples/Legacy Web/Cloud-UACH/appsettings.json
@@ -11,9 +11,9 @@
     "Elements": [
       {
         "BuilderName": "CloudRequestEngine",
-        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs
+        // A free resource key created at https://configure.51degrees.com/Wkqxf3Bs?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-legacy-web-cloud-uach-appsettings.json&utm_term=elements
         // populates the free properties. A paid subscription key created at
-        // https://configure.51degrees.com/hYzn3TV3 includes all the properties
+        // https://configure.51degrees.com/hYzn3TV3?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-legacy-web-cloud-uach-appsettings.json&utm_term=elements includes all the properties
         // used by this example.
         // The properties used in this example are:
         //   HardwareVendor, HardwareName, DeviceType

--- a/Examples/Legacy Web/UACH/Startup.cs
+++ b/Examples/Legacy Web/UACH/Startup.cs
@@ -208,7 +208,7 @@ namespace Client_Hints
                             $"appsettings.json file. Also, note that the " +
                             $"free 'lite' data file is insufficient to run " +
                             $"this example. A paid-for file can be obtained " +
-                            $"from https://51degrees.com/pricing.");
+                            $"from https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-legacy-web-uach-startup.cs&utm_term=data-file-required.");
                     }
                 }
             }

--- a/Examples/OnPremise/Framework-Web/Default.aspx
+++ b/Examples/OnPremise/Framework-Web/Default.aspx
@@ -182,7 +182,7 @@
                 WARNING: You are using the free 'Lite' data file. This does not include the client-side
                 evidence capabilities of the paid-for data file, so you will not see any additional
                 data below. Find out about the Enterprise data file on our
-                <a href="https://51degrees.com/pricing">pricing page</a>.
+                <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-onpremise-framework-web-default.aspx&amp;utm_term=client-side-evidence-and-apple-models">pricing page</a>.
             </div>
         <% } %>
     </div>   

--- a/Examples/OnPremise/Framework-Web/Default.aspx.cs
+++ b/Examples/OnPremise/Framework-Web/Default.aspx.cs
@@ -73,7 +73,7 @@ using System.Web.UI;
 /// Note that you will need to update the configuration with the complete path to a data file. 
 /// The free 'lite' file is included with this repository under the path 
 /// `FiftyOne.DeviceDetection\device-detection-cxx\device-detection-data`
-/// Alternatively, you can obtain a [license key](http://51degrees.com/pricing) which can be used 
+/// Alternatively, you can obtain a [license key](https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-onpremise-framework-web-default.aspx.cs&amp;utm_term=header) which can be used 
 /// to download a data file from our 
 /// [Distributor](/documentation/4.5/_services__distributor.html) service.
 /// 

--- a/Examples/OnPremise/GettingStarted-Console/Program.cs
+++ b/Examples/OnPremise/GettingStarted-Console/Program.cs
@@ -52,7 +52,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedConsole
             {
                 // In this example, we use the DeviceDetectionPipelineBuilder and configure it
                 // in code. For more information about builders in general see the documentation at
-                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-gettingstarted-console-program.cs&utm_term=run
 
                 // Note that we wrap the creation of a pipeline in a using to control its life cycle
                 using (var pipeline = new DeviceDetectionPipelineBuilder(loggerFactory)
@@ -60,9 +60,9 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedConsole
                     // We use the low memory profile as its performance is sufficient for this
                     // example. See the documentation for more detail on this and other
                     // configuration options:
-                    // https://51degrees.com/documentation/_device_detection__features__performance_options.html
-                    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
-                    // https://51degrees.com/documentation/_features__usage_sharing.html
+                    // https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-gettingstarted-console-program.cs&utm_term=run
+                    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-gettingstarted-console-program.cs&utm_term=run
+                    // https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-gettingstarted-console-program.cs&utm_term=run
                     .SetPerformanceProfile(PerformanceProfiles.LowMemory)
                     // inhibit sharing usage for this example, usually this should be set to "true"
                     .SetShareUsage(false)
@@ -137,7 +137,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedConsole
 
                     // Display the results of the detection, which are called device properties.
                     // See the property dictionary at
-                    // https://51degrees.com/developers/property-dictionary
+                    // https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-gettingstarted-console-program.cs&utm_term=run
                     // for details of all available properties.
                     OutputValue("Mobile Device", device.IsMobile, message);
                     OutputValue("Platform Name", device.PlatformName, message);
@@ -182,7 +182,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedConsole
                 //
                 // Note that the Lite data file is only used for illustration, and has limited accuracy
                 // and capabilities. Find out about the Enterprise data file on our pricing page:
-                // https://51degrees.com/pricing
+                // https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-gettingstarted-console-program.cs&utm_term=main
                 ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
 
             // Configure a logger to output to the console.

--- a/Examples/OnPremise/GettingStarted-Web/Views/Home/Index.cshtml
+++ b/Examples/OnPremise/GettingStarted-Web/Views/Home/Index.cshtml
@@ -75,7 +75,7 @@
         from the 
         <a href="https://github.com/51Degrees/device-detection-data">device-detection-data</a>
         repository on GitHub. Find out about the Enterprise data file, which includes automatic 
-        daily updates, on our <a href="https://51degrees.com/pricing">pricing page</a>.
+        daily updates, on our <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-onpremise-gettingstarted-web-views-home-index.cshtml&amp;utm_term=client-hints">pricing page</a>.
     </div>
 }
 
@@ -186,7 +186,7 @@
         WARNING: You are using the free 'Lite' data file. This does not include the client-side
         evidence capabilities of the paid-for data file, so you will not see any additional
         data below. Find out about the Enterprise data file on our
-        <a href="https://51degrees.com/pricing">pricing page</a>.
+        <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-onpremise-gettingstarted-web-views-home-index.cshtml&amp;utm_term=client-side-evidence-and-apple-models">pricing page</a>.
     </div>
     }
 </div>

--- a/Examples/OnPremise/MatchMetrics-Console/Program.cs
+++ b/Examples/OnPremise/MatchMetrics-Console/Program.cs
@@ -123,7 +123,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.MatchMetrics
                     // in the device ID value.
                     //.SetProperty("BrowserName")
                     // If using the full on-premise data file this property will be
-                    // present in the data file. See https://51degrees.com/pricing
+                    // present in the data file. See https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-matchmetrics-console-program.cs&utm_term=run
                     .SetProperty("HardwareName")
                     // Only use the predictive graph to better handle variances
                     // between the training data and the target User-Agent string.
@@ -173,7 +173,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.MatchMetrics
                                     "name ---");
                             output.WriteLine("For a discussion of what the match properties mean, see: " +
                                     "https://51degrees.com/documentation/4.5/_device_detection__hash" +
-                                    ".html#DeviceDetection_Hash_DataSetProduction\n");
+                                    ".html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-matchmetrics-console-program.cs&utm_term=run#DeviceDetection_Hash_DataSetProduction\n");
                             
                             // get the properties available from the DeviceDetection engine
                             // which has the key "device". For the sake of illustration we will

--- a/Examples/OnPremise/Metadata-Console/Program.cs
+++ b/Examples/OnPremise/Metadata-Console/Program.cs
@@ -97,8 +97,8 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.Metadata
                     // We use the low memory profile as its performance is sufficient for this
                     // example. See the documentation for more detail on this and other
                     // configuration options:
-                    // https://51degrees.com/documentation/_device_detection__features__performance_options.html
-                    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
+                    // https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-metadata-console-program.cs&utm_term=run
+                    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-metadata-console-program.cs&utm_term=run
                     .SetPerformanceProfile(profile)
                     // inhibit auto-update of the data file for this test
                     .SetAutoUpdate(false)
@@ -237,7 +237,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.Metadata
                 //
                 // Note that the Lite data file is only used for illustration, and has limited accuracy
                 // and capabilities. Find out about the Enterprise data file on our pricing page:
-                // https://51degrees.com/pricing
+                // https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-metadata-console-program.cs&utm_term=main
                 ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
 
             // Configure a logger to output to the console.

--- a/Examples/OnPremise/OfflineProcessing-Console/Program.cs
+++ b/Examples/OnPremise/OfflineProcessing-Console/Program.cs
@@ -99,7 +99,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.OfflineProcessing
                 var logger = loggerFactory.CreateLogger<Program>();
                 // In this example, we use the DeviceDetectionPipelineBuilder and configure it
                 // in code. For more information about builders in general see the documentation at
-                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=run
 
                 // Note that we wrap the creation of a pipeline in a using to control its life cycle
                 using (var pipeline = new DeviceDetectionPipelineBuilder(loggerFactory)
@@ -107,9 +107,9 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.OfflineProcessing
                     // We use the low memory profile as its performance is sufficient for this
                     // example. See the documentation for more detail on this and other
                     // configuration options:
-                    // https://51degrees.com/documentation/_device_detection__features__performance_options.html
-                    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
-                    // https://51degrees.com/documentation/_features__usage_sharing.html
+                    // https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=run
+                    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=run
+                    // https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=run
                     .SetPerformanceProfile(profile)
                     // Inhibit sharing usage for this example.
                     // In general, off line processing usage should NOT be shared back to 51Degrees.
@@ -119,7 +119,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.OfflineProcessing
                     // in order to help us improve detection of new devices/browsers/etc, then
                     // this additional data will need to be collected and included as evidence
                     // to the Pipeline. See
-                    // https://51degrees.com/documentation/_features__usage_sharing.html#Low_Level_Usage_Sharing
+                    // https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=run#Low_Level_Usage_Sharing
                     // for more details on this.
                     .SetShareUsage(false)
                     // Inhibit auto-update of the data file for this example
@@ -189,7 +189,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.OfflineProcessing
 
                     // Other fields can easily be added when available in the source data file.
                     // The following could be uncommented when used with a paid for Enterprise
-                    // data file. See https://51degrees.com/developers/property-dictionary
+                    // data file. See https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=analyseevidence
                     // for a full list of available properties.
 
                     //output.Add("device.hardwarevendor", device.HardwareVendor.GetHumanReadable());
@@ -225,7 +225,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.OfflineProcessing
                 //
                 // Note that the Lite data file is only used for illustration, and has limited accuracy
                 // and capabilities. Find out about the Enterprise data file on our pricing page:
-                // https://51degrees.com/pricing
+                // https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=main
                 ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
             // Do the same for the yaml evidence file.
             var evidenceFile = args.Length > 1 ? args[1] :

--- a/Examples/OnPremise/Performance-Console/Program.cs
+++ b/Examples/OnPremise/Performance-Console/Program.cs
@@ -330,7 +330,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.Performance
                     //
                     // Note that the Lite data file is only used for illustration, and has limited accuracy
                     // and capabilities. Find out about the Enterprise data file on our pricing page:
-                    // https://51degrees.com/pricing
+                    // https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-performance-console-program.cs&utm_term=main
                     ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
                 // Do the same for the yaml evidence file.
                 var evidenceFile = options.EvidenceFile != null ? options.EvidenceFile :

--- a/Examples/OnPremise/UpdateDataFile-Console/Program.cs
+++ b/Examples/OnPremise/UpdateDataFile-Console/Program.cs
@@ -43,10 +43,10 @@ using System.Net.Http;
 /// # License Key
 /// In order to test this example you will need a 51Degrees Enterprise license which can be
 /// purchased from our
-/// <a href="https://51degrees.com/pricing">pricing page</a>.
+/// <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-onpremise-updatedatafile-console-program.cs&amp;utm_term=header">pricing page</a>.
 /// 
 /// # Data Files
-/// You can find out more about data files, licenses etc. at our [FAQ page](https://51degrees.com/resources/faqs)
+/// You can find out more about data files, licenses etc. at our [FAQ page](https://51degrees.com/resources/faqs?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-dotnet-examples&amp;utm_content=examples-onpremise-updatedatafile-console-program.cs&amp;utm_term=header)
 /// 
 /// ## Enterprise Data File
 /// Enterprise (fully-featured) data files are typically released by 51Degrees five days a week
@@ -261,7 +261,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.UpdateDataFile
                         // file to a temporary file (createTempDataCopy parameter == true).
                         //
                         // For automatic updates to work you will also need to provide a license key.
-                        // A license key can be obtained with a subscription from https://51degrees.com/pricing
+                        // A license key can be obtained with a subscription from https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-updatedatafile-console-program.cs&utm_term=run
                         .UseOnPremise(dataFile, licenseKey, true)
                         // Enable update on startup, the auto update system
                         // will be used to check for an update before the
@@ -350,7 +350,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.UpdateDataFile
                 {
                     logger.LogError("In order to test this example you will need a 51Degrees " +
                         "Enterprise license which can be obtained on a trial basis or purchased " +
-                        "from our pricing page https://51degrees.com/pricing. You must supply the " +
+                        "from our pricing page https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-updatedatafile-console-program.cs&utm_term=license-key-required. You must supply the " +
                         "license key " + keySubmissionPaths);
                     throw new ArgumentException("No license key available", nameof(licenseKey));
                 }

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ The cloud property tiers changed in May 2026. The examples and this
 documentation now reflect what is free and what needs a paid subscription.
 
 A free resource key that selects the free tier properties can be created
-[here](https://configure.51degrees.com/Wkqxf3Bs). A resource key that also
+[here](https://configure.51degrees.com/Wkqxf3Bs?utm_source=github&utm_medium=readme&utm_campaign=device-detection-dotnet-examples&utm_content=readme.md&utm_term=cloud-resource-keys). A resource key that also
 includes the paid properties used by the examples can be created
-[here](https://configure.51degrees.com/hYzn3TV3). See
-https://51degrees.com/pricing to get a paid subscription with more properties.
+[here](https://configure.51degrees.com/hYzn3TV3?utm_source=github&utm_medium=readme&utm_campaign=device-detection-dotnet-examples&utm_content=readme.md&utm_term=cloud-resource-keys). See
+https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-dotnet-examples&utm_content=readme.md&utm_term=cloud-resource-keys to get a paid subscription with more properties.
 
 Of the properties the examples display, the free tier includes:
 
@@ -43,7 +43,7 @@ name checked first.
 
 Some on-premise examples require you to provide a license key. You can find
 out about resource keys and license keys at our [pricing
-page](https://51degrees.com/pricing).
+page](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-dotnet-examples&utm_content=readme.md&utm_term=cloud-resource-keys-2).
 
 ## On-premise data file
 


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

70 links across 32 files, in-place URL replacements only. While tagging, http, www, and protocol-relative variants were normalised to https on the bare domain, pre-2026 utm schemes were replaced, and the retired Logo.ashx banner URL was replaced with img/logo.png where present. Functional endpoints (cloud, distributor, devices-v4, bulkdata), test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).