### PR TITLE
Render a placeholder for properties missing from the resource key

### DIFF
--- a/Examples/ExampleBase/DataExtensions.cs
+++ b/Examples/ExampleBase/DataExtensions.cs
@@ -49,7 +49,7 @@ namespace FiftyOne.DeviceDetection.Examples
             }
             catch (PropertyMissingException pex)
             {
-                result = $"Unknown ({pex.Message})";
+                result = pex.Message;
             }
             return result;
         }
@@ -63,15 +63,26 @@ namespace FiftyOne.DeviceDetection.Examples
         /// <returns></returns>
         public static string GetHumanReadable(this IAspectPropertyValue<string> apv)
         {
-            return apv.HasValue ? apv.Value : $"Unknown ({apv.NoValueMessage})";
+            return apv != null && apv.HasValue ? apv.Value : NoValue(apv);
         }
         public static string GetHumanReadable(this IAspectPropertyValue<IReadOnlyList<string>> apv)
         {
-            return apv.HasValue ? string.Join(", ", apv.Value) : $"Unknown ({apv.NoValueMessage})";
+            return apv != null && apv.HasValue ? string.Join(", ", apv.Value) : NoValue(apv);
         }
         public static string GetHumanReadable(this IAspectPropertyValue<int> apv)
         {
-            return apv.HasValue ? apv.Value.ToString() : $"Unknown ({apv.NoValueMessage})";
+            return apv != null && apv.HasValue ? apv.Value.ToString() : NoValue(apv);
+        }
+
+        /// <summary>
+        /// Build the 'Unknown' message for a property that has no value. Handles the
+        /// case where the property is entirely absent from the response (a null
+        /// <see cref="IAspectPropertyValue{T}"/>), which happens when the resource key
+        /// or data file does not include the property.
+        /// </summary>
+        private static string NoValue<T>(IAspectPropertyValue<T> apv)
+        {
+            return $"No value ({(apv == null ? "property missing from the resource key or data file" : apv.NoValueMessage)})";
         }
     }
 }


### PR DESCRIPTION
Fixes #857

The cloud web examples returned HTTP 500 (NullReferenceException) when the resource key does not grant a property the example displays. The value helpers in `DataExtensions` dereferenced a null `IAspectPropertyValue` (the cloud engine returns null for an absent property rather than throwing `PropertyMissingException`), and `TryGetValue` only catches `PropertyMissingException`, so the exception escaped.

This null-guards the helpers so an absent property renders a placeholder instead of throwing, matching the Node, PHP, Python and Java examples. Verified locally under the basic key: the page returns 200 and renders the placeholder cells instead of 500.

Draft for review.