### PR TITLE
Render "Unknown" for properties missing from the resource key

### DIFF
--- a/Examples/ExampleBase/DataExtensions.cs
+++ b/Examples/ExampleBase/DataExtensions.cs
@@ -63,15 +63,26 @@ namespace FiftyOne.DeviceDetection.Examples
         /// <returns></returns>
         public static string GetHumanReadable(this IAspectPropertyValue<string> apv)
         {
-            return apv.HasValue ? apv.Value : $"Unknown ({apv.NoValueMessage})";
+            return apv != null && apv.HasValue ? apv.Value : NoValue(apv);
         }
         public static string GetHumanReadable(this IAspectPropertyValue<IReadOnlyList<string>> apv)
         {
-            return apv.HasValue ? string.Join(", ", apv.Value) : $"Unknown ({apv.NoValueMessage})";
+            return apv != null && apv.HasValue ? string.Join(", ", apv.Value) : NoValue(apv);
         }
         public static string GetHumanReadable(this IAspectPropertyValue<int> apv)
         {
-            return apv.HasValue ? apv.Value.ToString() : $"Unknown ({apv.NoValueMessage})";
+            return apv != null && apv.HasValue ? apv.Value.ToString() : NoValue(apv);
+        }
+
+        /// <summary>
+        /// Build the 'Unknown' message for a property that has no value. Handles the
+        /// case where the property is entirely absent from the response (a null
+        /// <see cref="IAspectPropertyValue{T}"/>), which happens when the resource key
+        /// or data file does not include the property.
+        /// </summary>
+        private static string NoValue<T>(IAspectPropertyValue<T> apv)
+        {
+            return $"Unknown ({(apv == null ? "property missing from the resource key or data file" : apv.NoValueMessage)})";
         }
     }
 }


### PR DESCRIPTION
The cloud web examples returned HTTP 500 when the resource key did not grant a property the page displays. The value helpers in `DataExtensions` dereferenced a null `IAspectPropertyValue`, because the cloud engine returns null for a property that is entirely absent rather than throwing `PropertyMissingException`, and `TryGetValue` only catches that exception. The `NullReferenceException` therefore escaped and the request failed.

This null-guards the helpers so an absent property renders "Unknown (property missing from the resource key or data file)", matching the Node, PHP, Python and Java examples.

This was never caught in CI because the web tests only load the client-side static.html and testpage.html, never the server-rendered page that builds the property table.

Fixes #857