### PR TITLE
fix on-prem web test data-file resolution under WebApplicationFactory

### DIFF
--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.ClientOnly/GettingStartedTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.ClientOnly/GettingStartedTest.cs
@@ -25,7 +25,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace FiftyOne.DeviceDetection.Example.Tests.Web.Cloud.ClientOnly
 {
-    public class GettingStartedTest : GettingStartedTestBase<Program>
+    public class GettingStartedTest : GettingStartedTestBase<Program, WebApplicationFactory<Program>>
     {
         public GettingStartedTest(WebApplicationFactory<Program> factory) : base(factory) { }
     }

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud/GettingStartedTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud/GettingStartedTest.cs
@@ -25,7 +25,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace FiftyOne.DeviceDetection.Example.Tests.Web.Cloud
 {
-    public class GettingStartedTest : GettingStartedTestOverrides<Program>
+    public class GettingStartedTest : GettingStartedTestOverrides<Program, WebApplicationFactory<Program>>
     {
         public GettingStartedTest(WebApplicationFactory<Program> factory) : base(factory) { }
     }

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/DataFileWebApplicationFactory.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/DataFileWebApplicationFactory.cs
@@ -1,0 +1,67 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.DeviceDetection.Examples;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using System.Collections.Generic;
+
+namespace FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise
+{
+    /// <summary>
+    /// The on-premise examples keep the relative data file name in
+    /// appsettings.json and rewrite it to an absolute path at runtime by
+    /// walking the directory hierarchy. That rewrite lives in the example's
+    /// <c>Program.Run</c> startup path, which is not exercised when the example
+    /// is hosted through <see cref="WebApplicationFactory{T}"/> - so the engine
+    /// builder would resolve the bare relative name against the test process
+    /// working directory (the test bin), where the data file is not present.
+    /// This factory performs the same resolution on the WebApplicationFactory
+    /// hosting path so those tests find the shared data file.
+    /// </summary>
+    public class DataFileWebApplicationFactory<T> : WebApplicationFactory<T>
+        where T : class
+    {
+        private const string LiteDataFileName = "51Degrees-LiteV4.1.hash";
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            // FindDataFile honours the 51DEGREES_DD_PATH / DEVICEDETECTIONDATAFILE
+            // environment variables before falling back to the directory search,
+            // matching the precedence used by the example itself.
+            var dataFile = ExampleUtils.FindDataFile(LiteDataFileName);
+            if (string.IsNullOrEmpty(dataFile) == false)
+            {
+                builder.ConfigureAppConfiguration(config =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string>
+                    {
+                        ["PipelineOptions:Elements:0:BuildParameters:DataFile"] = dataFile
+                    });
+                });
+            }
+
+            base.ConfigureWebHost(builder);
+        }
+    }
+}

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/GettingStartedTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/GettingStartedTest.cs
@@ -21,13 +21,12 @@
  * ********************************************************************* */
 
 using FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb;
-using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise
 {
-    public class GettingStartedTest : GettingStartedTestOverrides<Program>
+    public class GettingStartedTest : GettingStartedTestOverrides<Program, DataFileWebApplicationFactory<Program>>
     {
-        public GettingStartedTest(WebApplicationFactory<Program> factory) : base(factory) { }
+        public GettingStartedTest(DataFileWebApplicationFactory<Program> factory) : base(factory) { }
 
         protected override bool SupportsPropertyOverrides => false;
     }

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedTestBase.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedTestBase.cs
@@ -30,12 +30,13 @@ using Xunit;
 
 namespace FiftyOne.DeviceDetection.Example.Tests.Web
 {
-    public class GettingStartedTestBase<T>: IClassFixture<WebApplicationFactory<T>>
+    public class GettingStartedTestBase<T, TFactory> : IClassFixture<TFactory>
         where T : class
+        where TFactory : WebApplicationFactory<T>
     {
-        protected readonly WebApplicationFactory<T> Factory;
+        protected readonly TFactory Factory;
 
-        public GettingStartedTestBase(WebApplicationFactory<T> factory)
+        public GettingStartedTestBase(TFactory factory)
         {
             Factory = factory;
         }

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedTestOverrides.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web/GettingStartedTestOverrides.cs
@@ -32,10 +32,11 @@ using Xunit;
 
 namespace FiftyOne.DeviceDetection.Example.Tests.Web
 {
-    public class GettingStartedTestOverrides<T> : GettingStartedTestBase<T>
+    public class GettingStartedTestOverrides<T, TFactory> : GettingStartedTestBase<T, TFactory>
         where T : class
+        where TFactory : WebApplicationFactory<T>
     {
-        public GettingStartedTestOverrides(WebApplicationFactory<T> factory) : base(factory) { }
+        public GettingStartedTestOverrides(TFactory factory) : base(factory) { }
 
         /// <summary>
         /// Profile ids to use for testing. These are extracted from 51Degrees


### PR DESCRIPTION
The on-prem web `GettingStartedTest` resolves the data file via `Program.Run`'s override, which `WebApplicationFactory` skips under the .NET 10 host builder - so the relative `51Degrees-LiteV4.1.hash` resolved against the test `bin` and was not found (114 failures in `device-detection-dotnet` integration). A factory-side resolver now applies the same lookup on the hosting path, independent of SDK/runtime.

## Changes
- Add [`DataFileWebApplicationFactory`](https://github.com/51degrees/device-detection-dotnet-examples/blob/fix/data-file-path/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/DataFileWebApplicationFactory.cs) - resolves the data file (env var → directory walk) and injects it via `ConfigureWebHost`.
- Parameterize the shared web test bases over the factory type; on-prem uses the new factory, Cloud/ClientOnly keep the default.