### PR TITLE
Align env var names with the main repo

### DIFF
--- a/Examples/ExampleBase/Constants.cs
+++ b/Examples/ExampleBase/Constants.cs
@@ -42,7 +42,7 @@ namespace FiftyOne.DeviceDetection.Examples
         public const string YAML_EVIDENCE_FILE_NAME = "20000 Evidence Records.yml";
 
         /// <summary>
-        /// Environment variable key for the license key file to use for the 
+        /// Environment variable key for the license key file to use for the
         /// tests.
         /// </summary>
         public const string LICENSE_KEY_ENV_VAR = "DEVICEDETECTIONLICENSEKEY_DOTNET";
@@ -52,7 +52,7 @@ namespace FiftyOne.DeviceDetection.Examples
         /// device detection data file. This aligned name is checked first,
         /// before any legacy variable names.
         /// </summary>
-        public const string DEVICE_DETECTION_DATA_FILE_ENV_VAR = "51DEGREES_DD_PATH";
+        public const string DEVICE_DETECTION_DATA_FILE_ENV_VAR = "_51DEGREES_DD_PATH";
 
         /// <summary>
         /// Legacy environment variable key used to supply an explicit path to

--- a/Examples/ExampleBase/ExampleUtils.cs
+++ b/Examples/ExampleBase/ExampleUtils.cs
@@ -40,7 +40,7 @@ namespace FiftyOne.DeviceDetection.Examples
         /// to use when running cloud examples. This aligned name is checked
         /// first, before any legacy variable names.
         /// </summary>
-        public const string CLOUD_RESOURCE_KEY_ENV_VAR = "51DEGREES_RESOURCE_KEY";
+        public const string CLOUD_RESOURCE_KEY_ENV_VAR = "_51DEGREES_RESOURCE_KEY";
 
         /// <summary>
         /// The legacy environment variable key used to get the resource key
@@ -157,9 +157,9 @@ namespace FiftyOne.DeviceDetection.Examples
         }
 
         /// <summary>
-        /// Uses a background task to search for the specified filename within the working 
+        /// Uses a background task to search for the specified filename within the working
         /// directory.
-        /// If the file cannot be found, the algorithm will move to the parent directory and 
+        /// If the file cannot be found, the algorithm will move to the parent directory and
         /// repeat the process.
         /// This continues until the file is found or a timeout is triggered.
         /// </summary>
@@ -219,7 +219,7 @@ namespace FiftyOne.DeviceDetection.Examples
         /// </summary>
         /// <param name="dataFile"></param>
         /// <param name="engineBuilder"></param>
-        public static DataFileInfo GetDataFileInfo(string dataFile, 
+        public static DataFileInfo GetDataFileInfo(string dataFile,
             DeviceDetectionHashEngineBuilder engineBuilder)
         {
             DataFileInfo result = new DataFileInfo();
@@ -337,7 +337,7 @@ namespace FiftyOne.DeviceDetection.Examples
         }
 
         /// <summary>
-        /// This collection contains the various input values that will be passed to the device 
+        /// This collection contains the various input values that will be passed to the device
         /// detection algorithm when running examples
         /// </summary>
         public static readonly List<Dictionary<string, object>>
@@ -371,8 +371,8 @@ namespace FiftyOne.DeviceDetection.Examples
                     "\"Google Chrome\";v=\"98\"" },
                 { "header.sec-ch-ua-platform", "\"Windows\"" },
                 { "header.sec-ch-ua-platform-version", "\"14.0.0\"" }
-            }, 
-            
+            },
+
             //A note on User-Agent Client Hint representations:
             //There are 3 common ways to represent UACH:
             //- [HTTP header map](https://wicg.github.io/ua-client-hints/)
@@ -388,14 +388,14 @@ namespace FiftyOne.DeviceDetection.Examples
             //spec](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#objectuseragent)
 
             //51Degrees historically used HTTP header map to represent User-Agent Client Hints and expected the evidence to
-            //be provided as HTTP headers (or same name query parameters).  
+            //be provided as HTTP headers (or same name query parameters).
 
             //However in version 4.5 we introduced the ability to perform device detection using the 2 other User-Agent
             //Client Hints representations as evidence (internally it is done through conversion to the HTTP-header
             //representation, but it's an implementation detail).  The 2 evidence parameter names in question are:
             //`51D_gethighentropyvalues` and `51D_structureduseragent` - the engine consumes them as either
             //query or cookie params.
-            
+
             new Dictionary<string, object>()
             {
 
@@ -418,13 +418,13 @@ namespace FiftyOne.DeviceDetection.Examples
              "SwibW9iaWxlIjpmYWxzZSwibW9kZWwiOiIiLCJwbGF0Zm9ybSI6Im1hY09TIiwicGxhdGZvcm1WZXJzaW9uIjoiMTUuMS4xIn0="
              },
             },
-        
+
             //`query.51D_structureduseragent` or `cookie.51D_structureduseragent` is a JSON-string representation of
             //User-Agent Client Hints used in the
             //[OpenRTB 2.6](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#objectuseragent)
             new Dictionary<string, object>()
             {
-            {"query.51D_structureduseragent", 
+            {"query.51D_structureduseragent",
                 "{\"browsers\":[{\"brand\":\"Chromium\",\"version\":[\"124\",\"0\",\"6367\",\"91\"]},{\"brand\":"+
                 "\"Google Chrome\",\"version\":[\"124\",\"0\",\"6367\",\"91\"]},{\"brand\":\"Not-A.Brand\",\"version\""+
                 ":[\"99\",\"0\",\"0\",\"0\"]}],\"platform\":{\"brand\":\"Windows\",\"version\":[\"14\",\"0\",\"0\"]},"+
@@ -456,7 +456,7 @@ namespace FiftyOne.DeviceDetection.Examples
 
         /// <summary>
         /// Get the resource key from the environment. The aligned
-        /// '51DEGREES_RESOURCE_KEY' variable is checked first, followed by
+        /// '_51DEGREES_RESOURCE_KEY' variable is checked first, followed by
         /// the legacy 'SUPER_RESOURCE_KEY' variable.
         /// </summary>
         /// <returns>
@@ -477,7 +477,7 @@ namespace FiftyOne.DeviceDetection.Examples
         /// <summary>
         /// Get the resource key from the environment and run the action with
         /// the value, or an empty string if no resource key is set. The
-        /// aligned '51DEGREES_RESOURCE_KEY' variable is checked first,
+        /// aligned '_51DEGREES_RESOURCE_KEY' variable is checked first,
         /// followed by the legacy 'SUPER_RESOURCE_KEY' variable.
         /// </summary>
         /// <param name="setValue"></param>

--- a/Examples/OnPremise/GettingStarted-Web/Program.cs
+++ b/Examples/OnPremise/GettingStarted-Web/Program.cs
@@ -44,7 +44,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb
 
         /// <summary>
         /// Used by unit tests to run the example in an almost identical manner
-        /// to a developer using the example. Returns the task that the web 
+        /// to a developer using the example. Returns the task that the web
         /// server is running in so that the test can trigger the cancellation
         /// token and then wait for the server to shutdown before finishing.
         /// </summary>
@@ -78,12 +78,12 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb
         /// <summary>
         /// Typically, something like this will not be necessary.
         /// The device detection API will accept an absolute or relative path for the data file.
-        /// However, if a relative path is specified, it will only look in the current working 
+        /// However, if a relative path is specified, it will only look in the current working
         /// directory.
-        /// In our examples, we have many different projects and we don't want to have a copy of 
+        /// In our examples, we have many different projects and we don't want to have a copy of
         /// the data file for every single one.
-        /// In order to handle this, we dynamically search the project directories for the data 
-        /// file location and then override the configured setting with the absolute path if 
+        /// In order to handle this, we dynamically search the project directories for the data
+        /// file location and then override the configured setting with the absolute path if
         /// necessary.
         /// In a real-world scenario, you can just put the data file in your working directory
         /// or use an absolute path in the configuration file.
@@ -102,7 +102,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb
             // Use the 'ErrorOnUnknownConfiguration' option to warn us if we've got any
             // misnamed configuration keys.
             section.Bind(options, (o) => { o.ErrorOnUnknownConfiguration = true; });
-			
+
             // Get the index of the device detection engine element in the config file so that
             // we can create an override key for it.
             var hashEngineOptions = options.GetElementConfig(nameof(DeviceDetectionHashEngine));
@@ -112,7 +112,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb
 
             // An explicit data file path supplied in an environment variable takes
             // precedence over the value in the configuration file. The aligned
-            // '51DEGREES_DD_PATH' variable is checked first, followed by the legacy
+            // '_51DEGREES_DD_PATH' variable is checked first, followed by the legacy
             // 'DEVICEDETECTIONDATAFILE' variable.
             var dataFile = Environment.GetEnvironmentVariable(
                 Constants.DEVICE_DETECTION_DATA_FILE_ENV_VAR);
@@ -133,7 +133,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb
                     $"'{Constants.DEVICE_DETECTION_DATA_FILE_ENV_VAR}' environment variable.");
             }
             // The data file location provided in the configuration may be using an absolute or
-            // relative path. If it is relative then search for a matching file using the 
+            // relative path. If it is relative then search for a matching file using the
             // ExampleUtils.FindFile function.
             else if (Path.IsPathRooted(dataFile) == false)
             {
@@ -144,7 +144,7 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedWeb
                     overrides.Add(dataFileConfigKey, newPath);
                     foundDataFile = true;
                 }
-            } 
+            }
             else
             {
                 foundDataFile = File.Exists(dataFile);

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ A paid subscription is needed for:
 - The TAC and native model hardware profile properties
 
 To use the resource key in the example it can be supplied as an environment
-variable called "51DEGREES_RESOURCE_KEY". The legacy environment variable name
-"SUPER_RESOURCE_KEY" is still supported, with the aligned "51DEGREES_RESOURCE_KEY"
+variable called "_51DEGREES_RESOURCE_KEY". The legacy environment variable name
+"SUPER_RESOURCE_KEY" is still supported, with the aligned "_51DEGREES_RESOURCE_KEY"
 name checked first.
 
 Some on-premise examples require you to provide a license key. You can find
@@ -50,10 +50,10 @@ page](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_camp
 The on-premise examples need a device detection data file. The examples locate
 the file in the following order:
 
-1. The "51DEGREES_DD_PATH" environment variable, which can be set to an
+1. The "_51DEGREES_DD_PATH" environment variable, which can be set to an
    explicit path to the data file. The legacy "DEVICEDETECTIONDATAFILE"
    environment variable is also still supported, and is checked after
-   "51DEGREES_DD_PATH".
+   "_51DEGREES_DD_PATH".
 2. A search of the folder hierarchy, walking up from the working directory,
    for the expected data file name.
 3. The free 'Lite' data file in its expected location, which is the
@@ -61,7 +61,7 @@ the file in the following order:
 
 Note that the aligned variable names start with a digit, which POSIX shells
 do not accept in plain assignments. On Linux and macOS set them with the env
-command, for example `env 51DEGREES_RESOURCE_KEY=AAA dotnet run`.
+command, for example `env _51DEGREES_RESOURCE_KEY=AAA dotnet run`.
 
 ## Running examples with changes to Pipeline packages
 

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud/Parameters.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.Cloud/Parameters.cs
@@ -51,7 +51,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web.Cloud
                 // BrowserVersion
                 // In addition, each key will need to have specific setup
                 // for the '*Accept-CH' properties:
-                // 51DEGREES_RESOURCE_KEY (or legacy SUPER_RESOURCE_KEY) -
+                // _51DEGREES_RESOURCE_KEY (or legacy SUPER_RESOURCE_KEY) -
                 //    SetHeaderBrowserAccept-CH, SetHeaderHardwareAccept-CH,
                 //    SetHeaderPlatformAccept-CH
                 // ACCEPTCH_BROWSER_KEY - SetHeaderBrowserAccept-CH only

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/ClientHintsTest.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/ClientHintsTest.cs
@@ -71,7 +71,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise
                     "data file that is included with the source code. " +
                     "A paid-for data file can be obtained from " +
                     "https://51degrees.com/pricing You can then configure " +
-                    "the 51DEGREES_DD_PATH environment variable " +
+                    "the _51DEGREES_DD_PATH environment variable " +
                     "with the full path to the file.");
             }
 

--- a/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/DataFileWebApplicationFactory.cs
+++ b/Tests/FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise/DataFileWebApplicationFactory.cs
@@ -46,7 +46,7 @@ namespace FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
-            // FindDataFile honours the 51DEGREES_DD_PATH / DEVICEDETECTIONDATAFILE
+            // FindDataFile honours the _51DEGREES_DD_PATH / DEVICEDETECTIONDATAFILE
             // environment variables before falling back to the directory search,
             // matching the precedence used by the example itself.
             var dataFile = ExampleUtils.FindDataFile(LiteDataFileName);

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -25,12 +25,8 @@ if ($IsLinux) {
 
 dotnet dev-certs https
 
-$env:DEVICEDETECTIONDATAFILE = [IO.Path]::Combine($RepoPath, "device-detection-data", "TAC-HashV41.hash")
-$env:SUPER_RESOURCE_KEY = $Keys.TestResourceKey
-# Aligned environment variable names. These are checked first by the examples
-# and tests. The legacy names above are retained for backwards compatibility.
-${env:51DEGREES_DD_PATH} = [IO.Path]::Combine($RepoPath, "device-detection-data", "TAC-HashV41.hash")
-${env:51DEGREES_RESOURCE_KEY} = $Keys.TestResourceKey
+$env:_51DEGREES_DD_PATH = [IO.Path]::Combine($RepoPath, "device-detection-data", "TAC-HashV41.hash")
+$env:_51DEGREES_RESOURCE_KEY = $Keys.TestResourceKey
 $env:DEVICEDETECTIONLICENSEKEY_DOTNET = $Keys.DeviceDetection
 $env:ACCEPTCH_BROWSER_KEY = $Keys.AcceptCHBrowserKey
 $env:ACCEPTCH_HARDWARE_KEY = $Keys.AcceptCHHardwareKey


### PR DESCRIPTION
`device-detection-dotnet` switched to underscore-prefixed 51DEGREES variables to avoid issues with software that expects them to be valid identifier.