### PR TITLE
Update Lite data file comments to reflect actual difference

### DIFF
--- a/Examples/ExampleBase/ExampleUtils.cs
+++ b/Examples/ExampleBase/ExampleUtils.cs
@@ -315,8 +315,9 @@ namespace FiftyOne.DeviceDetection.Examples
                 }
                 if (info.Tier == "Lite")
                 {
-                    logger.LogWarning($"This example is using the 'Lite' data file. This is " +
-                        $"used for illustration, and has limited accuracy and capabilities. " +
+                    logger.LogWarning($"This example is using the 'Lite' data file. This " +
+                        $"contains a more limited set of properties than the Enterprise " +
+                        $"data file. " +
                         $"Find out about the Enterprise data file on our pricing page: " +
                         $"https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-examplebase-exampleutils.cs&utm_term=lite-data-file");
                 }

--- a/Examples/OnPremise/GettingStarted-Console/Program.cs
+++ b/Examples/OnPremise/GettingStarted-Console/Program.cs
@@ -180,8 +180,8 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.GettingStartedConsole
                 // In this example, by default, the 51degrees "Lite" file needs to be somewhere in the
                 // project space, or you may specify another file as a command line parameter.
                 //
-                // Note that the Lite data file is only used for illustration, and has limited accuracy
-                // and capabilities. Find out about the Enterprise data file on our pricing page:
+                // Note that the Lite data file contains a more limited set of properties than the
+                // Enterprise data file. Find out about the Enterprise data file on our pricing page:
                 // https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-gettingstarted-console-program.cs&utm_term=main
                 ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
 

--- a/Examples/OnPremise/Metadata-Console/Program.cs
+++ b/Examples/OnPremise/Metadata-Console/Program.cs
@@ -235,8 +235,8 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.Metadata
                 // In this example, by default, the 51degrees "Lite" file needs to be somewhere in the
                 // project space, or you may specify another file as a command line parameter.
                 //
-                // Note that the Lite data file is only used for illustration, and has limited accuracy
-                // and capabilities. Find out about the Enterprise data file on our pricing page:
+                // Note that the Lite data file contains a more limited set of properties than the
+                // Enterprise data file. Find out about the Enterprise data file on our pricing page:
                 // https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-metadata-console-program.cs&utm_term=main
                 ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
 

--- a/Examples/OnPremise/OfflineProcessing-Console/Program.cs
+++ b/Examples/OnPremise/OfflineProcessing-Console/Program.cs
@@ -223,8 +223,8 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.OfflineProcessing
                 // In this example, by default, the 51degrees "Lite" file needs to be somewhere in the
                 // project space, or you may specify another file as a command line parameter.
                 //
-                // Note that the Lite data file is only used for illustration, and has limited accuracy
-                // and capabilities. Find out about the Enterprise data file on our pricing page:
+                // Note that the Lite data file contains a more limited set of properties than the
+                // Enterprise data file. Find out about the Enterprise data file on our pricing page:
                 // https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=main
                 ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
             // Do the same for the yaml evidence file.

--- a/Examples/OnPremise/Performance-Console/Program.cs
+++ b/Examples/OnPremise/Performance-Console/Program.cs
@@ -328,8 +328,8 @@ namespace FiftyOne.DeviceDetection.Examples.OnPremise.Performance
                     // In this example, by default, the 51degrees "Lite" file needs to be somewhere in the
                     // project space, or you may specify another file as a command line parameter.
                     //
-                    // Note that the Lite data file is only used for illustration, and has limited accuracy
-                    // and capabilities. Find out about the Enterprise data file on our pricing page:
+                    // Note that the Lite data file contains a more limited set of properties than the
+                    // Enterprise data file. Find out about the Enterprise data file on our pricing page:
                     // https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-dotnet-examples&utm_content=examples-onpremise-performance-console-program.cs&utm_term=main
                     ExampleUtils.FindDataFile(Constants.LITE_HASH_DATA_FILE_NAME);
                 // Do the same for the yaml evidence file.


### PR DESCRIPTION
## Summary

Several examples contained comments (and one runtime log warning) claiming the Lite data file has "limited accuracy and capabilities" compared to the Enterprise file. In V4 the only difference between Lite and Enterprise is that Lite exposes fewer properties — accuracy is the same. This PR rewords those messages to describe the actual distinction.

Changed locations:
- `Examples/ExampleBase/ExampleUtils.cs` — the shared log warning shown when a Lite file is in use
- `Examples/OnPremise/GettingStarted-Console/Program.cs`
- `Examples/OnPremise/Performance-Console/Program.cs`
- `Examples/OnPremise/OfflineProcessing-Console/Program.cs`
- `Examples/OnPremise/Metadata-Console/Program.cs`

Other Lite-related messages in the repo (web example banners, UACH startup warnings, test skip messages) already correctly refer to missing properties or paid features rather than accuracy, so they are unchanged.

Resolves #788

## Test plan

- Comment-only change; `Examples/ExampleBase` (the one file where the change touches a string literal) builds with 0 warnings / 0 errors.
